### PR TITLE
bugfix in server_state, meta_state_service_simple & unittest of meta_state_service

### DIFF
--- a/src/apps/replication/meta_server/meta_state_service_simple.cpp
+++ b/src/apps/replication/meta_server/meta_state_service_simple.cpp
@@ -291,11 +291,11 @@ namespace dsn
             _offset += log_writer.total_size();
 
             auto returned_task_ptr = tasking::create_late_task(cb_code, cb_create, 0, tracker);
-            auto continuation_task = std::make_unique<operation>(false, [=](bool log_succeed)
+            auto continuation_task = std::unique_ptr<operation>(new operation(false, [=](bool log_succeed)
             {
                 dassert(log_succeed, "we cannot handle logging failure now");
                 __err_cb_bind_and_enqueue(returned_task_ptr, create_node_internal(node, value), 0);
-            });
+            }));
             auto continuation_task_ptr = continuation_task.get();
             _task_queue.emplace(std::move(continuation_task));
             _log_lock.unlock();
@@ -338,11 +338,11 @@ namespace dsn
             _offset += log_writer.total_size();
 
             auto returned_task_ptr = tasking::create_late_task(cb_code, cb_delete, 0, tracker);
-            auto continuation_task = std::make_unique<operation>(false, [=](bool log_succeed)
+            auto continuation_task = std::unique_ptr<operation>(new operation(false, [=](bool log_succeed)
             {
                 dassert(log_succeed, "we cannot handle logging failure now");
                 __err_cb_bind_and_enqueue(returned_task_ptr, delete_node_internal(node, recursively_delete), 0);
-            });
+            }));
             auto continuation_task_ptr = continuation_task.get();
             _task_queue.emplace(std::move(continuation_task));
 
@@ -442,11 +442,11 @@ namespace dsn
             _offset += log_writer.total_size();
 
             auto returned_task_ptr = tasking::create_late_task(cb_code, cb_set_data, 0, tracker);
-            auto continuation_task = std::make_unique<operation>(false, [=](bool log_succeed)
+            auto continuation_task = std::unique_ptr<operation>(new operation(false, [=](bool log_succeed)
             {
                 dassert(log_succeed, "we cannot handle logging failure now");
                 __err_cb_bind_and_enqueue(returned_task_ptr, set_data_internal(node, value), 0);
-            });
+            }));
             auto continuation_task_ptr = continuation_task.get();
             _task_queue.emplace(std::move(continuation_task));
 

--- a/src/apps/replication/meta_server/meta_state_service_simple.h
+++ b/src/apps/replication/meta_server/meta_state_service_simple.h
@@ -93,6 +93,7 @@ namespace dsn
                 task_code cb_code,
                 const err_stringv_callback& cb_get_children,
                 clientlet* tracker = nullptr) override;
+            ~meta_state_service_simple();
 
         private:
 

--- a/src/apps/replication/meta_server/server_state.cpp
+++ b/src/apps/replication/meta_server/server_state.cpp
@@ -223,7 +223,7 @@ error_code server_state::sync_apps_from_remote_storage()
                     _storage->get_data(
                         app_path,
                         LPC_META_STATE_SVC_CALLBACK,
-                        [this, app_path, &err, &tracker](error_code ec, blob& value)
+                        [this, app_path, &err, &tracker](error_code ec, blob&& value)
                     {
                         if (ec == ERR_OK)
                         {
@@ -252,7 +252,7 @@ error_code server_state::sync_apps_from_remote_storage()
                                 _storage->get_data(
                                     par_path,
                                     LPC_META_STATE_SVC_CALLBACK,
-                                    [this, app_id, i, &err](error_code ec, blob& value)
+                                    [this, app_id, i, &err](error_code ec, blob&& value)
                                     {
                                         if (ec == ERR_OK)
                                         {

--- a/src/tests/meta_state_service.cpp
+++ b/src/tests/meta_state_service.cpp
@@ -1,0 +1,73 @@
+#include <meta_state_service_simple.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <thread>
+
+using namespace dsn;
+DEFINE_TASK_CODE(META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, TASK_PRIORITY_HIGH, THREAD_POOL_DEFAULT);
+TEST(meta_state_service_simple, basics)
+{
+    //environment
+    auto service = new ::dsn::dist::meta_state_service_simple();
+    service->initialize();
+    //bondary check
+#define expect_ok  [](error_code ec){EXPECT_TRUE(ec == ERR_OK);}
+#define expect_err [](error_code ec){EXPECT_FALSE(ec == ERR_OK);}
+    service->node_exist("/", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+    service->node_exist("", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_err)->wait();
+    //recursive delete test
+    {
+        service->create_node("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->node_exist("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->create_node("/1/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->get_children("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, [](error_code ec, std::vector<std::string>&& children)
+        {
+            dassert(ec == ERR_OK && children.size() == 1 && *children.begin() == "1", "unexpected child");
+        });
+        service->node_exist("/1/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->delete_node("/1", false, META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_err)->wait();
+        service->delete_node("/1", true, META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->node_exist("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_err)->wait();
+    }
+    //repeat create test
+    {
+        service->create_node("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->create_node("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_err)->wait();
+    }
+    //check replay
+    {
+        delete service;
+        service = new ::dsn::dist::meta_state_service_simple();
+        service->initialize();
+        service->node_exist("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->node_exist("/1/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_err)->wait();
+        service->delete_node("/1", false, META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+    }
+    //set & get data
+    {
+        dsn::binary_writer writer;
+        writer.write(0xdeadbeef);
+        service->create_node("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok, writer.get_buffer())->wait();
+        service->get_data("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, [](error_code ec, const dsn::blob&& value)
+        {
+            expect_ok(ec);
+            dsn::binary_reader reader(value);
+            int read_value;
+            reader.read(read_value);
+            dassert(read_value == 0xdeadbeef, "get_value != create_value");
+        })->wait();
+        writer = dsn::binary_writer();
+        writer.write(0xbeefdead);
+        service->set_data("/1", writer.get_buffer(), META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, expect_ok)->wait();
+        service->get_data("/1", META_STATE_SERVICE_SIMPLE_TEST_CALLBACK, [](error_code ec, dsn::blob&& value)
+        {
+            expect_ok(ec);
+            dsn::binary_reader reader(value);
+            int read_value;
+            reader.read(read_value);
+            dassert(read_value == 0xbeefdead, "get_value != create_value");
+        })->wait();
+    }
+#undef expect_ok
+#undef expect_err
+}


### PR DESCRIPTION
Simple_kv is now runnable and restartable under simulator and nativerun.
bugfix explanation:
(1) bugfix in meta_state_service: log recoverability, lifetime of file write buffers, some unhandled errorcode
(2) bugfix in server_state: a deadlock, a misconfiguration of tracker (the num_bucket should be set to 1 because there would be new tasks attached to the tracker when the tracker is waiting for tasks), a missed lock and a off-by-one error
