### PR TITLE
vectorized mutation log & multiple bug fixes

### DIFF
--- a/include/dsn/cpp/clientlet.h
+++ b/include/dsn/cpp/clientlet.h
@@ -243,6 +243,16 @@ namespace dsn
             int hash = 0
             );
 
+        task_ptr write_vector(
+            dsn_handle_t fh,
+            const dsn_file_buffer_t* buffers,
+            int buffer_count,
+            uint64_t offset,
+            dsn_task_code_t callback_code,
+            clientlet* svc,
+            aio_handler callback,
+            int hash = 0
+            );
 
         template<typename T> // where T : public virtual clientlet
         inline task_ptr read(

--- a/include/dsn/cpp/perf_test_helper.h
+++ b/include/dsn/cpp/perf_test_helper.h
@@ -120,7 +120,9 @@ namespace dsn {
                     *this = r;
                 }
 
-                perf_test_case()
+                perf_test_case() : id(0), seconds(0), payload_bytes(0), concurrency(0),
+                    timeout_ms(0), timeout_rounds(0), error_rounds(0), succ_rounds(0),
+                    succ_latency_avg_ns(0), succ_qps(0), succ_throughput_MB_s(0)
                 {}
             };
 

--- a/include/dsn/cpp/task_helper.h
+++ b/include/dsn/cpp/task_helper.h
@@ -148,7 +148,7 @@ namespace dsn
         {
         }
 
-        safe_task(THandler& h) : _handler(h)
+        safe_task(THandler& h) : _handler(h), _is_timer(false)
         {
         }
 

--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -153,7 +153,7 @@ namespace dsn {
 
         bool has_holder() const { return _holder.get() != nullptr; }
 
-        const char* buffer_ptr() { return _holder.get(); }
+        const char* buffer_ptr() const { return _holder.get(); }
 
         blob range(int offset) const
         {

--- a/include/dsn/internal/task.h
+++ b/include/dsn/internal/task.h
@@ -335,6 +335,31 @@ public:
     size_t          get_transferred_size() const { return _transferred_size; }
     disk_aio*       aio() { return _aio; }
 
+    void copy_to(char* dest)
+    {
+        if (!_unmerged_write_buffers.empty())
+        {
+            for (auto &buffer : _unmerged_write_buffers)
+            {
+                memcpy(dest, buffer.buffer, buffer.size);
+                dest += buffer.size;
+            }
+        }
+        else
+        {
+            memcpy(dest, _aio->buffer, _aio->buffer_size);
+        }
+    }
+
+    void collapse() {
+        if (!_unmerged_write_buffers.empty()) {
+            auto buffer = std::shared_ptr<char>(new char[_aio->buffer_size]);
+            _merged_write_buffer_holder.assign(buffer, 0, _aio->buffer_size);
+            _aio->buffer = buffer.get();
+            copy_to(buffer.get());
+        }
+    }
+
     virtual void exec() override // aio completed
     {
         if (nullptr != _cb)
@@ -347,6 +372,8 @@ public:
         }
     }
 
+    std::vector<dsn_file_buffer_t> _unmerged_write_buffers;
+    blob                      _merged_write_buffer_holder;
 protected:
     disk_aio*         _aio;
     size_t            _transferred_size;

--- a/include/dsn/service_api_c.h
+++ b/include/dsn/service_api_c.h
@@ -737,7 +737,7 @@ extern DSN_API void          dsn_rpc_enqueue_response(
 typedef struct
 {
     void* buffer;
-    size_t size;
+    int size;
 }dsn_file_buffer_t;
 
 // return nullptr if open failed

--- a/include/dsn/service_api_c.h
+++ b/include/dsn/service_api_c.h
@@ -733,6 +733,13 @@ extern DSN_API void          dsn_rpc_enqueue_response(
 // file operations
 //
 //------------------------------------------------------------------------------
+
+typedef struct
+{
+    void* buffer;
+    size_t size;
+}dsn_file_buffer_t;
+
 // return nullptr if open failed
 extern DSN_API dsn_handle_t dsn_file_open(
                                 const char* file_name, 
@@ -766,6 +773,13 @@ extern DSN_API void         dsn_file_write(
                                 const char* buffer, 
                                 int count, 
                                 uint64_t offset, 
+                                dsn_task_t cb
+                                );
+extern DSN_API void         dsn_file_write_vector(
+                                dsn_handle_t file,
+                                const dsn_file_buffer_t* buffers,
+                                int buffer_count,
+                                uint64_t offset,
                                 dsn_task_t cb
                                 );
 extern DSN_API void         dsn_file_copy_remote_directory(

--- a/src/apps/replication/client_lib/replication_common.cpp
+++ b/src/apps/replication/client_lib/replication_common.cpp
@@ -71,7 +71,8 @@ replication_options::replication_options()
 
     working_dir = ".";
         
-    log_batch_buffer_MB = 1;
+    log_batch_buffer_KB_shared = 0;
+    log_batch_buffer_KB_private = 4;
     log_pending_max_ms = 100;
     log_file_size_mb = 32;
     log_buffer_size_mb_private = 1;
@@ -230,12 +231,18 @@ void replication_options::initialize()
         log_file_size_mb,
         "maximum log segment file size (MB)"
         );
-    log_batch_buffer_MB =
+    log_batch_buffer_KB_shared =
         (int)dsn_config_get_value_uint64("replication", 
-        "log_batch_buffer_MB", 
-        log_batch_buffer_MB,
-        "log buffer size (MB) for batching incoming logs"
+        "log_batch_buffer_KB_shared", 
+        log_batch_buffer_KB_shared,
+        "shared log buffer size (KB) for batching incoming logs"
         );
+    log_batch_buffer_KB_private =
+        (int)dsn_config_get_value_uint64("replication",
+            "log_batch_buffer_KB_private",
+            log_batch_buffer_KB_private,
+            "private log buffer size (KB) for batching incoming logs"
+            );
     log_pending_max_ms =
         (int)dsn_config_get_value_uint64("replication", 
         "log_pending_max_ms", 

--- a/src/apps/replication/client_lib/replication_common.h
+++ b/src/apps/replication/client_lib/replication_common.h
@@ -92,7 +92,8 @@ public:
     bool    log_enable_private_prepare;
 
     int32_t log_file_size_mb;
-    int32_t log_batch_buffer_MB;
+    int32_t log_batch_buffer_KB_shared;
+    int32_t log_batch_buffer_KB_private;
     int32_t log_pending_max_ms;
     int32_t log_file_size_mb_private;
     int32_t log_buffer_size_mb_private;

--- a/src/apps/replication/lib/mutation.h
+++ b/src/apps/replication/lib/mutation.h
@@ -71,7 +71,7 @@ public:
     void set_left_secondary_ack_count(unsigned int count) { _left_secondary_ack_count = count; }
     void set_left_potential_secondary_ack_count(unsigned int count) { _left_potential_secondary_ack_count = count; }
     int  clear_prepare_or_commit_tasks();
-    int  clear_log_task();
+    void wait_log_task() const;
     void set_prepare_ts() { _prepare_ts_ms = dsn_now_ms(); }
 
     // >= 1 MB
@@ -79,6 +79,7 @@ public:
     
     // reader & writer
     static mutation_ptr read_from(binary_reader& readeer, dsn_message_t from);
+    void write_to_scatter(std::function<void(blob)> inserter) const;
     void write_to(binary_writer& writer);
 
     // data

--- a/src/apps/replication/lib/replica.h
+++ b/src/apps/replication/lib/replica.h
@@ -150,7 +150,7 @@ private:
     void on_prepare_reply(std::pair<mutation_ptr, partition_status> pr, error_code err, dsn_message_t request, dsn_message_t reply);
     void do_possible_commit_on_primary(mutation_ptr& mu);    
     void ack_prepare_message(error_code err, mutation_ptr& mu);
-    void cleanup_preparing_mutations(bool is_primary);
+    void cleanup_preparing_mutations(bool wait);
     
     /////////////////////////////////////////////////////////////////
     // learning    

--- a/src/apps/replication/lib/replica_config.cpp
+++ b/src/apps/replication/lib/replica_config.cpp
@@ -575,7 +575,7 @@ bool replica::update_local_configuration(const replica_configuration& config, bo
     switch (old_status)
     {
     case PS_PRIMARY:
-        cleanup_preparing_mutations(true);
+        cleanup_preparing_mutations(false);
         switch (config.status)
         {
         case PS_PRIMARY:
@@ -596,7 +596,7 @@ bool replica::update_local_configuration(const replica_configuration& config, bo
         }        
         break;
     case PS_SECONDARY:
-        cleanup_preparing_mutations(true);
+        cleanup_preparing_mutations(false);
         switch (config.status)
         {
         case PS_PRIMARY:

--- a/src/apps/replication/lib/replica_init.cpp
+++ b/src/apps/replication/lib/replica_init.cpp
@@ -187,7 +187,7 @@ error_code replica::init_app_and_prepare_list(const char* app_type, bool create_
             _private_log = new mutation_log(
                 log_dir,
                 true,
-                _options->log_batch_buffer_MB,
+                _options->log_batch_buffer_KB_private,
                 _options->log_file_size_mb
                 );
         }
@@ -361,7 +361,7 @@ bool replica::replay_mutation(mutation_ptr& mu, bool is_private)
         _private_log->append(mu,
             LPC_WRITE_REPLICATION_LOG,
             this,
-            [this](error_code err, size_t size)
+            [this, mu](error_code err, size_t size)
         {
             if (err != ERR_OK)
             {

--- a/src/apps/replication/lib/replica_learn.cpp
+++ b/src/apps/replication/lib/replica_learn.cpp
@@ -255,7 +255,7 @@ void replica::on_learn(dsn_message_t msg, const learn_request& request)
             // start from (last_committed_decree + 1)
             it->second.prepare_start_decree = local_committed_decree + 1;
 
-            cleanup_preparing_mutations(true);
+            cleanup_preparing_mutations(false);
             
             // the replayed prepare msg needs to be AFTER the learning response msg
             delayed_replay_prepare_list = true;
@@ -791,6 +791,7 @@ error_code replica::apply_learned_state_from_private_log(learn_state& state)
                 return false;
 
             plist.prepare(mu, PS_SECONDARY);
+            mu->set_logged();
         }
     }
 

--- a/src/apps/replication/lib/replica_stub.cpp
+++ b/src/apps/replication/lib/replica_stub.cpp
@@ -110,7 +110,7 @@ void replica_stub::initialize(const replication_options& opts, bool clear/* = fa
     _log = new mutation_log(
         log_dir,
         false,
-        opts.log_batch_buffer_MB,
+        opts.log_batch_buffer_KB_shared,
         opts.log_file_size_mb
         );
 

--- a/src/apps/replication/meta_server/meta_state_service_simple.cpp
+++ b/src/apps/replication/meta_server/meta_state_service_simple.cpp
@@ -105,7 +105,7 @@ namespace dsn
 
             file::write(
                 _log,
-                log_blob.buffer_ptr(),
+                log_blob.data(),
                 log_blob.length(),
                 log_offset,
                 LPC_META_STATE_SERVICE_SIMPLE_INTERNAL,

--- a/src/apps/replication/meta_server/meta_state_service_simple.h
+++ b/src/apps/replication/meta_server/meta_state_service_simple.h
@@ -142,7 +142,7 @@ namespace dsn
                     marshall(writer, static_cast<int>(op));
                     write(writer, head, tail...);
                     auto shared_blob = writer.get_buffer();
-                    reinterpret_cast<log_header*>((char*)shared_blob.buffer_ptr())->size = shared_blob.length() - sizeof(log_header);
+                    reinterpret_cast<log_header*>((char*)shared_blob.data())->size = shared_blob.length() - sizeof(log_header);
                     return shared_blob;
                 }
                 static void write(binary_writer& writer, const Head& head, const Tail&... tail)

--- a/src/core/core/disk_engine.cpp
+++ b/src/core/core/disk_engine.cpp
@@ -321,6 +321,7 @@ void disk_engine::process_write(aio_task* aio, uint32_t sz)
     // no batching
     if (aio->aio()->buffer_size == sz)
     {
+        aio->collapse();
         return _provider->aio(aio);
     }
 
@@ -333,14 +334,8 @@ void disk_engine::process_write(aio_task* aio, uint32_t sz)
         auto current_wk = aio;
         do
         {
-            auto dio = current_wk->aio();
-            memcpy(
-                (void*)ptr,
-                (const void*)(dio->buffer),
-                (size_t)(dio->buffer_size)
-                );
-
-            ptr += dio->buffer_size;
+            current_wk->copy_to(ptr);
+            ptr += current_wk->aio()->buffer_size;
             current_wk = (aio_task*)current_wk->next;
         } while (current_wk);
 

--- a/src/core/core/disk_engine.cpp
+++ b/src/core/core/disk_engine.cpp
@@ -338,6 +338,7 @@ void disk_engine::process_write(aio_task* aio, uint32_t sz)
             ptr += current_wk->aio()->buffer_size;
             current_wk = (aio_task*)current_wk->next;
         } while (current_wk);
+        
 
         dassert(ptr == (char*)bb.data() + bb.length(), "");
 

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -690,6 +690,24 @@ DSN_API void dsn_file_write(dsn_handle_t file, const char* buffer, int count, ui
     ::dsn::task::get_current_disk()->write(callback);
 }
 
+DSN_API void dsn_file_write_vector(dsn_handle_t file, const dsn_file_buffer_t* buffers, int buffer_count, uint64_t offset, dsn_task_t cb)
+{
+    ::dsn::aio_task* callback((::dsn::aio_task*)cb);
+    callback->aio()->buffer = nullptr;
+    callback->aio()->buffer_size = 0;
+    callback->aio()->engine = nullptr;
+    callback->aio()->file = file;
+    callback->aio()->file_offset = offset;
+    callback->aio()->type = ::dsn::AIO_Write;
+    for (int i = 0; i < buffer_count; i ++)
+    {
+        callback->_unmerged_write_buffers.push_back(buffers[i]);
+        callback->aio()->buffer_size += buffers[i].size;
+    }
+
+    ::dsn::task::get_current_disk()->write(callback);
+}
+
 DSN_API void dsn_file_copy_remote_directory(dsn_address_t remote, const char* source_dir, 
     const char* dest_dir, bool overwrite, dsn_task_t cb)
 {


### PR DESCRIPTION
new service_api : dsn_file_write_vector
new configurations in [replication] : log_batch_buffer_KB_shared (default value 0) & log_batch_buffer_KB_private (default value 4). 

fixed bugs in mutation_log, private log learning & private log writing.
