### PR TITLE
  enable separated [core]data_dir for all logs/coredumps/app data.  

### DIFF
--- a/bin/dsn.ext.copy.cmd
+++ b/bin/dsn.ext.copy.cmd
@@ -19,7 +19,16 @@ GOTO copy_latest
     SET ltime=
     IF EXIST "%PROJ_LIB_DIR%\%lconfig%" (
         ECHO CHECK dir %PROJ_LIB_DIR%\%lconfig% ... 
-        FOR /f "tokens=1,2,3" %%i IN ('dir /o:d /TW "%PROJ_LIB_DIR%\%lconfig%" ^| find "/"' ) DO SET ltime=%%i %%j %%k
+        FOR /f "tokens=1,2,3" %%i IN ('dir /o:d /TW "%PROJ_LIB_DIR%\%lconfig%" ^| find "/"' ) DO (
+            SET valid_k=0
+            if "%%k" EQU "AM" SET valid_k=1
+            if "%%k" EQU "PM" SET valid_k=1
+            if "valid_k" EQU "1" (
+                SET ltime=%%i %%j %%k
+            ) else (
+                SET ltime=%%i %%j
+            )
+        )
     )
     IF "%max_time%" EQU "" (
         SET max_time=%ltime%

--- a/include/dsn/internal/global_config.h
+++ b/include/dsn/internal/global_config.h
@@ -93,6 +93,7 @@ struct service_app_spec
 {
     int                  id;    // global id for all roles, assigned by rDSN automatically, also named as "app_id"
     int                  index; // local index for the current role (1,2,3,...), also named as "role_index"
+    std::string          data_dir; // data dir for the app. it is auto-set as ${service_spec.data_dir}/${service_app_spec.name}.
     std::string          config_section; // [apps.${role_name}]
     std::string          role_name;  // role name of [apps.${role_name}], also named as "app_name"
     std::string          name;  // combined by role_name and role_index, also named as "app_full_name"
@@ -156,7 +157,7 @@ struct service_spec
 
     std::string                  tool;   // the main tool (only 1 is allowed for a time)
     std::list<std::string>       toollets; // toollets enabled compatible to the main tool
-    std::string                  coredump_dir; // to store core dump files
+    std::string                  data_dir; // to store all data/log/coredump etc.
     bool                         start_nfs;
     
     std::string                  timer_factory_name;
@@ -192,6 +193,10 @@ struct service_spec
     std::vector<threadpool_spec>  threadpool_specs;
     std::vector<service_app_spec> app_specs;
 
+    // auto-set
+    std::string                   dir_coredump;
+    std::string                   dir_log;
+
     service_spec() {}
     bool init();
     bool init_app_specs();
@@ -202,7 +207,7 @@ struct service_spec
 CONFIG_BEGIN(service_spec)
     CONFIG_FLD_STRING(tool, "", "use what tool to run this process, e.g., native or simulator")
     CONFIG_FLD_STRING_LIST(toollets, "use what toollets, e.g., tracer, profiler, fault_injector")
-    CONFIG_FLD_STRING(coredump_dir, "./coredump", "where to put the core dump files")
+    CONFIG_FLD_STRING(data_dir, "./data", "where to put the all the data/log/coredump, etc..")
     CONFIG_FLD(bool, bool, start_nfs, false, "whether to start nfs")
     CONFIG_FLD_STRING(timer_factory_name, "", "timer service provider")
     CONFIG_FLD_STRING(aio_factory_name, "", "asynchonous file system provider")

--- a/include/dsn/internal/logging_provider.h
+++ b/include/dsn/internal/logging_provider.h
@@ -43,15 +43,15 @@ namespace dsn {
 class logging_provider
 {
 public:
-    template <typename T> static logging_provider* create()
+    template <typename T> static logging_provider* create(const char* log_dir)
     {
-        return new T();
+        return new T(log_dir);
     }
 
-    typedef logging_provider* (*factory)();
+    typedef logging_provider* (*factory)(const char*);
 
 public:
-    logging_provider() {}
+    logging_provider(const char*) {}
 
     virtual ~logging_provider(void) { }
     

--- a/include/dsn/service_api_c.h
+++ b/include/dsn/service_api_c.h
@@ -107,6 +107,7 @@ extern "C" {
 # define DSN_INVALID_HASH                  0xdeadbeef
 # define DSN_MAX_APP_TYPE_NAME_LENGTH      32
 # define DSN_MAX_APP_COUNT_IN_SAME_PROCESS 256
+# define DSN_MAX_PATH                      1024
 
 //------------------------------------------------------------------------------
 //
@@ -185,6 +186,7 @@ struct dsn_app_info
     char  role[DSN_MAX_APP_TYPE_NAME_LENGTH]; // app role name
     char  type[DSN_MAX_APP_TYPE_NAME_LENGTH]; // app type name
     char  name[DSN_MAX_APP_TYPE_NAME_LENGTH]; // app full name
+    char  data_dir[DSN_MAX_PATH];             // app data directory
 };
 
 // the following ctrl code are used by dsn_file_ctrl
@@ -298,6 +300,7 @@ extern DSN_API void dsn_run(int argc, char** argv, bool sleep_after_init DEFAULT
 extern DSN_API void dsn_terminate();
 extern DSN_API int  dsn_get_all_apps(dsn_app_info* info_buffer, int count); // return real app count
 extern DSN_API bool dsn_get_current_app_info(/*out*/ dsn_app_info* app_info);
+extern DSN_API const char* dsn_get_current_app_data_dir();
 
 //
 // app roles must be registered (dsn_app_register_role)

--- a/src/apps/replication/client_lib/replication_common.cpp
+++ b/src/apps/replication/client_lib/replication_common.cpp
@@ -72,9 +72,7 @@ replication_options::replication_options()
     fd_beacon_interval_seconds = 3;
     fd_lease_seconds = 10;
     fd_grace_seconds = 15;
-
-    working_dir = ".";
-        
+            
     log_batch_buffer_KB_shared = 0;
     log_batch_buffer_KB_private = 4;
     log_pending_max_ms = 100;
@@ -244,11 +242,6 @@ void replication_options::initialize()
         "fd_grace_seconds", 
         fd_grace_seconds,
         "grace (seconds) assigned to remote FD slaves (grace > lease)"
-        );
-    working_dir = dsn_config_get_value_string("replication", 
-        "working_dir", 
-        working_dir.c_str(),
-        "root working directory for replication"
         );
     
     log_file_size_mb =

--- a/src/apps/replication/client_lib/replication_common.h
+++ b/src/apps/replication/client_lib/replication_common.h
@@ -64,7 +64,6 @@ typedef std::unordered_map< ::dsn::rpc_address, dsn::task_ptr> node_tasks;
 class replication_options
 {
 public:
-    std::string working_dir;
     std::vector< ::dsn::rpc_address> meta_servers;
 
     int32_t prepare_timeout_ms_for_secondaries;

--- a/src/apps/replication/lib/replica_stub.cpp
+++ b/src/apps/replication/lib/replica_stub.cpp
@@ -80,7 +80,7 @@ void replica_stub::initialize(const replication_options& opts, bool clear/* = fa
 
     // init dirs
     set_options(opts);
-    _dir = _options.working_dir;
+    _dir = std::string(dsn_get_current_app_data_dir());
     _primary_address = primary_address();
     
     if (clear)

--- a/src/apps/replication/lib/replication_service_app.cpp
+++ b/src/apps/replication/lib/replication_service_app.cpp
@@ -66,10 +66,7 @@ replication_service_app::~replication_service_app(void)
 error_code replication_service_app::start(int argc, char** argv)
 {
     replication_options opts;
-    std::string app_name(argv[0]); 
-    
     opts.initialize();    
-    opts.working_dir = utils::filesystem::path_combine(opts.working_dir, app_name);
 
     _stub->initialize(opts);
     _stub->open_service();

--- a/src/apps/replication/meta_server/meta_server_failure_detector.cpp
+++ b/src/apps/replication/meta_server/meta_server_failure_detector.cpp
@@ -126,7 +126,7 @@ void meta_server_failure_detector::on_worker_connected(::dsn::rpc_address node)
 }
 
 DEFINE_TASK_CODE(LPC_META_SERVER_LEADER_LOCK_CALLBACK, TASK_PRIORITY_COMMON, THREAD_POOL_FD)
-DEFINE_TASK_CODE_RPC(RPC_CM_QUERY_LEADER_LOCK, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
+DEFINE_TASK_CODE(LPC_CM_QUERY_LEADER_LOCK, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
 DEFINE_TASK_CODE(LPC_CM_QUERY_LEADER_LOCK_TIMER, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
 
 void meta_server_failure_detector::acquire_leader_lock()
@@ -153,7 +153,7 @@ void meta_server_failure_detector::acquire_leader_lock()
 
             query_leader_task = _lock_svc->query_lock(
                 _primary_lock_id,
-                RPC_CM_QUERY_LEADER_LOCK,
+                LPC_CM_QUERY_LEADER_LOCK,
                 [this, &query_leader_task](error_code ec, const std::string& owner_id, uint64_t version)
                 {
                     if (ec == ERR_OK)

--- a/src/apps/replication/meta_server/meta_service_app.cpp
+++ b/src/apps/replication/meta_server/meta_service_app.cpp
@@ -98,7 +98,7 @@ namespace dsn {
 
         ::dsn::error_code meta_service_app::start(int argc, char** argv)
         {
-            _state->initialize(name().c_str());
+            _state->initialize(dsn_get_current_app_data_dir());
             _service->start();
             return ERR_OK;
         }

--- a/src/core/core/global_config.cpp
+++ b/src/core/core/global_config.cpp
@@ -277,9 +277,11 @@ service_app_spec::service_app_spec(const service_app_spec& r)
     ports_gap = r.ports_gap;
     run = r.run;
     dmodule = r.dmodule;
+    dmodule_bridge_arguments = r.dmodule_bridge_arguments;
     network_client_confs = r.network_client_confs;
     network_server_confs = r.network_server_confs;
     count = r.count;
+    data_dir = r.data_dir;
 }
 
 bool service_app_spec::init(
@@ -495,6 +497,7 @@ bool service_spec::init_app_specs()
                 app.name = (app.count > 1 ? (app.role_name + buf) : app.role_name);
                 app.id = ++app_id;
                 app.index = i;
+                app.data_dir = utils::filesystem::path_combine(data_dir, app.name);
 
                 // add app
                 app_specs.push_back(app);

--- a/src/core/core/service_engine.cpp
+++ b/src/core/core/service_engine.cpp
@@ -250,6 +250,10 @@ error_code service_node::start()
 {
     error_code err = ERR_OK;
 
+    // init data dir
+    if (!dsn::utils::filesystem::path_exists(spec().data_dir))
+        dsn::utils::filesystem::create_directory(spec().data_dir);
+
     // init task engine    
     _computation = new task_engine(this);
     _computation->create(_app_spec.pools);    
@@ -394,7 +398,7 @@ void service_engine::init_before_toollets(const service_spec& spec)
 
     // init common providers (first half)
     _logging = factory_store<logging_provider>::create(
-        spec.logging_factory_name.c_str(), PROVIDER_TYPE_MAIN, nullptr
+        spec.logging_factory_name.c_str(), PROVIDER_TYPE_MAIN, spec.dir_log.c_str()
         );
     _memory = factory_store<memory_provider>::create(
         spec.memory_factory_name.c_str(), PROVIDER_TYPE_MAIN

--- a/src/core/perf.tests/logger.cpp
+++ b/src/core/perf.tests/logger.cpp
@@ -72,7 +72,7 @@ template<typename TLOGGER>
 void logger_test(int thread_count, int record_count)
 {
     std::list<std::thread*> threads;
-    TLOGGER logger;
+    TLOGGER logger("./");
 
     uint64_t nts = dsn_now_ns();
     uint64_t nts_start = nts;

--- a/src/core/tests/logger.cpp
+++ b/src/core/tests/logger.cpp
@@ -92,7 +92,7 @@ void log_print(logging_provider* logger, const char* fmt, ...) {
 TEST(tools_common, simple_logger)
 {
     //cases for print_header
-    screen_logger* logger = new screen_logger();
+    screen_logger* logger = new screen_logger("./");
     log_print(logger, "%s", "test_print");
     std::thread t([](screen_logger* lg){
         tls_dsn.magic = 0xdeadbeef;
@@ -106,7 +106,7 @@ TEST(tools_common, simple_logger)
     prepare_test_dir();
     //create multiple files
     for (unsigned int i=0; i<simple_logger_gc_gap + 10; ++i) {
-        simple_logger* logger = new simple_logger();
+        simple_logger* logger = new simple_logger("./");
         //in this case stdout is useless
         for (unsigned int i=0; i!=1000; ++i)
             log_print(logger, "%s", "test_print");

--- a/src/core/tools/common/simple_logger.cpp
+++ b/src/core/tools/common/simple_logger.cpp
@@ -98,7 +98,8 @@ namespace dsn {
             }
         }
 
-        screen_logger::screen_logger()
+        screen_logger::screen_logger(const char* log_dir)
+            : logging_provider(log_dir)
         {
             _short_header = dsn_config_get_value_bool("tools.screen_logger", "short_header",
                 true, "whether to use short header (excluding file/function etc.)");
@@ -133,8 +134,10 @@ namespace dsn {
             ::fflush(stdout);
         }
 
-        simple_logger::simple_logger() 
+        simple_logger::simple_logger(const char* log_dir)
+            : logging_provider(log_dir)
         {
+            _log_dir = std::string(log_dir);
             _start_index = 0;
             _index = 0;
             _lines = 0;
@@ -154,10 +157,9 @@ namespace dsn {
 
             // check existing log files
             std::vector<std::string> sub_list;
-            std::string path = "./";
-            if (!dsn::utils::filesystem::get_subfiles(path, sub_list, false))
+            if (!dsn::utils::filesystem::get_subfiles(_log_dir, sub_list, false))
             {
-                dassert(false, "Fail to get subfiles in %s.", path.c_str());
+                dassert(false, "Fail to get subfiles in %s.", _log_dir.c_str());
             }             
             for (auto& fpath : sub_list)
             {
@@ -192,7 +194,7 @@ namespace dsn {
             _lines = 0;
 
             std::stringstream str;
-            str << "log." << ++_index << ".txt";
+            str << _log_dir << "/log." << ++_index << ".txt";
             _log = ::fopen(str.str().c_str(), "w+");
 
             // TODO: move gc out of criticial path

--- a/src/core/tools/common/simple_logger.h
+++ b/src/core/tools/common/simple_logger.h
@@ -46,7 +46,7 @@ namespace dsn {
         class screen_logger : public logging_provider
         {
         public:
-            screen_logger();
+            screen_logger(const char* log_dir);
             virtual ~screen_logger(void);
 
             virtual void dsn_logv(const char *file,
@@ -69,7 +69,7 @@ namespace dsn {
         class simple_logger : public logging_provider
         {
         public:
-            simple_logger();
+            simple_logger(const char* log_dir);
             virtual ~simple_logger(void);
 
             virtual void dsn_logv(const char *file,
@@ -87,6 +87,7 @@ namespace dsn {
             void create_log_file();
 
         private:
+            std::string _log_dir;
             ::dsn::utils::ex_lock_nr _lock;
             FILE* _log;
             int _start_index;

--- a/src/core/tools/hpc/hpc_logger.cpp
+++ b/src/core/tools/hpc/hpc_logger.cpp
@@ -138,9 +138,10 @@ namespace dsn
             write_buffer_list(saved_list);
         }
 
-        hpc_logger::hpc_logger() 
-            : _stop_thread(false)
+        hpc_logger::hpc_logger(const char* log_dir) 
+            : logging_provider(log_dir), _stop_thread(false)
         {
+            _log_dir = std::string(log_dir);
             _per_thread_buffer_bytes = config()->get_value<int>(
                 "tools.hpc_logger",
                 "per_thread_buffer_bytes",
@@ -154,10 +155,9 @@ namespace dsn
 
             // check existing log files and decide start_index
             std::vector<std::string> sub_list;
-            std::string path = "./";
-            if (!dsn::utils::filesystem::get_subfiles(path, sub_list, false))
+            if (!dsn::utils::filesystem::get_subfiles(_log_dir, sub_list, false))
             {
-                dassert(false, "Fail to get subfiles in %s.", path.c_str());
+                dassert(false, "Fail to get subfiles in %s.", _log_dir.c_str());
             }
 
             for (auto& fpath : sub_list)
@@ -190,7 +190,7 @@ namespace dsn
         void hpc_logger::create_log_file()
         {
             std::stringstream log;
-            log << "log." << ++_index << ".txt";
+            log << _log_dir << "/log." << ++_index << ".txt";
             _current_log = new std::ofstream(log.str().c_str(), std::ofstream::out | std::ofstream::app | std::ofstream::binary);
             _current_log_file_bytes = 0;
 

--- a/src/core/tools/hpc/hpc_logger.h
+++ b/src/core/tools/hpc/hpc_logger.h
@@ -52,7 +52,7 @@ namespace dsn {
         class hpc_logger : public logging_provider
         {
         public:
-            hpc_logger();
+            hpc_logger(const char* log_dir);
             virtual ~hpc_logger(void);
 
             virtual void dsn_logv(const char *file,
@@ -78,6 +78,7 @@ namespace dsn {
         private:            
             bool        _stop_thread;
             std::thread _log_thread;
+            std::string _log_dir;
 
             // global buffer list
             std::condition_variable_any   _write_list_cond;
@@ -90,7 +91,7 @@ namespace dsn {
             int _per_thread_buffer_bytes;
             int _current_log_file_bytes;
 
-            // current write file
+            // current write file            
             std::ofstream *_current_log;
         };
     }

--- a/src/core/tools/hpc/hpc_tail_logger.cpp
+++ b/src/core/tools/hpc/hpc_tail_logger.cpp
@@ -72,8 +72,10 @@ namespace dsn
         
         static void hpc_tail_logs_dumpper();
 
-        hpc_tail_logger::hpc_tail_logger() 
+        hpc_tail_logger::hpc_tail_logger(const char* log_dir) 
+            : logging_provider(log_dir)
         {
+            _log_dir = std::string(log_dir);
             _per_thread_buffer_bytes = config()->get_value<int>(
                 "tools.hpc_tail_logger",
                 "per_thread_buffer_bytes",
@@ -140,11 +142,11 @@ namespace dsn
             hpc_tail_logs_dumpper();
         }
 
-        static void hpc_tail_logs_dumpper()
+        void hpc_tail_logger::hpc_tail_logs_dumpper()
         {
             uint64_t nts = dsn_now_ns();
             std::stringstream log;
-            log << ::dsn::tools::spec().coredump_dir << "/hpc_tail_logs." << nts << ".log";
+            log << _log_dir << "/hpc_tail_logs." << nts << ".log";
 
             std::ofstream olog(log.str().c_str());
 

--- a/src/core/tools/hpc/hpc_tail_logger.h
+++ b/src/core/tools/hpc/hpc_tail_logger.h
@@ -44,7 +44,7 @@ namespace dsn {
         class hpc_tail_logger : public logging_provider
         {
         public:
-            hpc_tail_logger();
+            hpc_tail_logger(const char* log_dir);
             virtual ~hpc_tail_logger(void);
 
             virtual void dsn_logv(const char *file,
@@ -60,9 +60,11 @@ namespace dsn {
 
         private:
             std::string search(const char* keyword, int back_seconds, int back_start_seconds, std::unordered_set<int>& target_threads);
-            
+            void hpc_tail_logs_dumpper();
+
         private:
             int _per_thread_buffer_bytes;
+            std::string _log_dir;
         };
     }
 }


### PR DESCRIPTION
[core] data_dir defines the root data directory
${data_dir}/coredump for coredumps
${data_dir}/logs for all logs
${data_dir}/${app_name} for all apps data dir
