### PR TITLE
enable task cancellation callback to avoid memory leak in cpp dev lib…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ -n "$DSN_ROOT"]
+then
+    export DSN_ROOT=`pwd`/install
+    echo export DSN_ROOT=$DSN_ROOT >> ~/.bashrc
+    echo export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$DSN_ROOT/lib >> ~/.bashrc
+    echo "================ THIS IS THE FIRST TIME REGISTER \$DSN_ROOT, please run source ~/.bashrc =========="
+fi
+
 CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_BUILD_TYPE=Debug"
 CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
 #CMAKE_OPTIONS="$CMAKE_OPTIONS -DDSN_DEBUG_CMAKE=TRUE"
@@ -13,7 +21,7 @@ CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
 #   cd boost_1_54_0
 #   ./bootstrap.sh --with-libraries=system,filesystem --with-toolset=gcc
 #   ./b2 toolset=gcc cxxflags="-std=c++11 -fPIC" -j8 -d0
-#   ./b2 install --prefix=`pwd`/output -d0
+#   ./b2 install --prefix=$DSN_ROOT -d0
 # And set BOOST_DIR as:
 #   export BOOST_DIR=/path/to/boost_1_54_0/output
 if [ -n "$BOOST_DIR" ]
@@ -33,7 +41,7 @@ then
     echo "Running cmake..."
     mkdir -p builder
     cd builder
-    cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/output $CMAKE_OPTIONS
+    cmake .. -DCMAKE_INSTALL_PREFIX=$DSN_ROOT $CMAKE_OPTIONS
     if [ $? -ne 0 ]
     then
         echo "ERROR: cmake failed"

--- a/include/dsn/cpp/clientlet.h
+++ b/include/dsn/cpp/clientlet.h
@@ -429,9 +429,10 @@ namespace dsn
                     auto task = new safe_task<rpc_reply_handler>(cb);
 
                     task->add_ref(); // released in exec_rpc_response
-                    auto t = dsn_rpc_create_response_task(
+                    auto t = dsn_rpc_create_response_task_ex(
                         msg,
                         safe_task<rpc_reply_handler >::exec_rpc_response,
+                        safe_task<rpc_reply_handler >::on_cancel,
                         (void*)task,
                         reply_hash,
                         owner ? owner->tracker() : nullptr
@@ -472,9 +473,10 @@ namespace dsn
                     auto task = new safe_task<rpc_reply_handler>(cb);
 
                     task->add_ref(); // released in exec_rpc_response
-                    auto t = dsn_rpc_create_response_task(
+                    auto t = dsn_rpc_create_response_task_ex(
                         msg,
                         safe_task<rpc_reply_handler >::exec_rpc_response,
+                        safe_task<rpc_reply_handler >::on_cancel,
                         (void*)task,
                         reply_hash,
                         owner ? owner->tracker() : nullptr
@@ -515,9 +517,10 @@ namespace dsn
                     auto task = new safe_task<rpc_reply_handler>(cb);
 
                     task->add_ref(); // released in exec_rpc_response
-                    auto t = dsn_rpc_create_response_task(
+                    auto t = dsn_rpc_create_response_task_ex(
                         msg,
                         safe_task<rpc_reply_handler >::exec_rpc_response,
+                        safe_task<rpc_reply_handler >::on_cancel,
                         (void*)task,
                         reply_hash,
                         owner ? owner->tracker() :  nullptr
@@ -557,9 +560,10 @@ namespace dsn
                     auto task = new safe_task<rpc_reply_handler>(cb);
 
                     task->add_ref(); // released in exec_rpc_response
-                    auto t = dsn_rpc_create_response_task(
+                    auto t = dsn_rpc_create_response_task_ex(
                         msg,
                         safe_task<rpc_reply_handler >::exec_rpc_response,
+                        safe_task<rpc_reply_handler >::on_cancel,
                         (void*)task,
                         reply_hash,
                         owner ? owner->tracker() : nullptr

--- a/include/dsn/cpp/task_helper.h
+++ b/include/dsn/cpp/task_helper.h
@@ -26,10 +26,10 @@
 
 /*
  * Description:
- *     What is this file about?
+ *     helpers for easier task programing atop of C api
  *
  * Revision history:
- *     xxxx-xx-xx, author, first version
+ *     Sep., 2015, @imzhenyu (Zhenyu Guo), first version
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
@@ -158,9 +158,14 @@ namespace dsn
             if (r)
             {
                 _handler = nullptr;
-                release_ref(); // added upon callback exec registration
             }
             return r;
+        }
+
+        static void on_cancel(void* task)
+        {
+            safe_task* t = (safe_task*)task;
+            t->release_ref(); // added upon callback exec registration
         }
 
         static void exec(void* task)

--- a/include/dsn/internal/task.h
+++ b/include/dsn/internal/task.h
@@ -110,7 +110,6 @@ public:
     virtual ~task();
         
     virtual void exec() = 0;
-    virtual void on_cancelled() {} // when the task is cancelled
 
     void                    exec_internal();    
     // return whether *this* cancel success, 

--- a/src/apps/replication/lib/mutation_log.cpp
+++ b/src/apps/replication/lib/mutation_log.cpp
@@ -778,8 +778,11 @@ void mutation_log::update_max_decrees(global_partition_id gpid, decree d)
     {
         tsk = new safe_task<aio_handler>(callback);
         tsk->add_ref(); // released in exec_aio
-        dsn_task_t t = dsn_file_create_aio_task(callback_code,
-            safe_task<aio_handler>::exec_aio, tsk, hash, callback_host->tracker());
+        dsn_task_t t = dsn_file_create_aio_task_ex(callback_code,
+            safe_task<aio_handler>::exec_aio,
+            safe_task<aio_handler>::on_cancel,
+            tsk, hash, callback_host->tracker()
+            );
         tsk->set_task_info(t);
         _pending_write_callbacks->push_back(tsk);
     }

--- a/src/core/core/disk_engine.cpp
+++ b/src/core/core/disk_engine.cpp
@@ -265,14 +265,14 @@ class batch_write_io_task : public aio_task
 {
 public:
     batch_write_io_task(aio_task* tasks, blob& buffer)
-        : aio_task(LPC_AIO_BATCH_WRITE, nullptr, tasks)
+        : aio_task(LPC_AIO_BATCH_WRITE, nullptr, tasks, nullptr)
     {
         _buffer = buffer;
     }
     
     virtual void exec() override
     {
-        aio_task* tasks = (aio_task*)_param;
+        aio_task* tasks = (aio_task*)_context;
         auto df = (disk_file*)tasks->aio()->file_object;
         uint32_t sz;
 

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -65,7 +65,7 @@ namespace dsn {
     {
     public:
         rpc_timeout_task(rpc_client_matcher* matcher, uint64_t id, service_node* node) 
-            : task(LPC_RPC_TIMEOUT, 0, node)
+            : task(LPC_RPC_TIMEOUT, nullptr, nullptr, 0, node)
         {
             _matcher = matcher;
             _id = id;

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -279,17 +279,34 @@ DSN_API uint32_t dsn_crc32_concatenate(uint32_t xy_init, uint32_t x_init, uint32
 // // TODO: what can be configured for a thread pool
 //
 //------------------------------------------------------------------------------
-DSN_API dsn_task_t dsn_task_create(dsn_task_code_t code, dsn_task_handler_t cb, void* param, int hash, dsn_task_tracker_t tracker)
+DSN_API dsn_task_t dsn_task_create(dsn_task_code_t code, dsn_task_handler_t cb, void* context, int hash, dsn_task_tracker_t tracker)
 {
-    auto t = new ::dsn::task_c(code, cb, param, hash);
+    auto t = new ::dsn::task_c(code, cb, context, nullptr, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     return t;
 }
 
 DSN_API dsn_task_t dsn_task_create_timer(dsn_task_code_t code, dsn_task_handler_t cb, 
-    void* param, int hash, int interval_milliseconds, dsn_task_tracker_t tracker)
+    void* context, int hash, int interval_milliseconds, dsn_task_tracker_t tracker)
 {
-    auto t = new ::dsn::timer_task(code, cb, param, interval_milliseconds, hash);
+    auto t = new ::dsn::timer_task(code, cb, context, nullptr, interval_milliseconds, hash);
+    t->set_tracker((dsn::task_tracker*)tracker);
+    return t;
+}
+
+DSN_API dsn_task_t dsn_task_create_ex(dsn_task_code_t code, dsn_task_handler_t cb, 
+    dsn_task_cancelled_handler_t on_cancel, void* context, int hash, dsn_task_tracker_t tracker)
+{
+    auto t = new ::dsn::task_c(code, cb, context, on_cancel, hash);
+    t->set_tracker((dsn::task_tracker*)tracker);
+    return t;
+}
+
+DSN_API dsn_task_t dsn_task_create_timer_ex(dsn_task_code_t code, dsn_task_handler_t cb,
+    dsn_task_cancelled_handler_t on_cancel, 
+    void* context, int hash, int interval_milliseconds, dsn_task_tracker_t tracker)
+{
+    auto t = new ::dsn::timer_task(code, cb, context, on_cancel, interval_milliseconds, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     return t;
 }
@@ -541,10 +558,21 @@ DSN_API void* dsn_rpc_unregiser_handler(dsn_task_code_t code)
     return (h != nullptr) ? h->parameter : nullptr;
 }
 
-DSN_API dsn_task_t dsn_rpc_create_response_task(dsn_message_t request, dsn_rpc_response_handler_t cb, void* param, int reply_hash, dsn_task_tracker_t tracker)
+DSN_API dsn_task_t dsn_rpc_create_response_task(dsn_message_t request, dsn_rpc_response_handler_t cb, 
+    void* context, int reply_hash, dsn_task_tracker_t tracker)
 {
     auto msg = ((::dsn::message_ex*)request);
-    auto t = new ::dsn::rpc_response_task(msg, cb, param, reply_hash);
+    auto t = new ::dsn::rpc_response_task(msg, cb, context, nullptr, reply_hash);
+    t->set_tracker((dsn::task_tracker*)tracker);
+    return t;
+}
+
+DSN_API dsn_task_t dsn_rpc_create_response_task_ex(dsn_message_t request, dsn_rpc_response_handler_t cb, 
+    dsn_task_cancelled_handler_t on_cancel,
+    void* context, int reply_hash, dsn_task_tracker_t tracker)
+{
+    auto msg = ((::dsn::message_ex*)request);
+    auto t = new ::dsn::rpc_response_task(msg, cb, context, on_cancel, reply_hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     return t;
 }
@@ -657,9 +685,18 @@ DSN_API void* dsn_file_native_handle(dsn_handle_t file)
     return dfile->native_handle();
 }
 
-DSN_API dsn_task_t dsn_file_create_aio_task(dsn_task_code_t code, dsn_aio_handler_t cb, void* param, int hash, dsn_task_tracker_t tracker)
+DSN_API dsn_task_t dsn_file_create_aio_task(dsn_task_code_t code, dsn_aio_handler_t cb, void* context, int hash, dsn_task_tracker_t tracker)
 {
-    auto t = new ::dsn::aio_task(code, cb, param, hash);
+    auto t = new ::dsn::aio_task(code, cb, context, nullptr, hash);
+    t->set_tracker((dsn::task_tracker*)tracker);
+    return t;
+}
+
+DSN_API dsn_task_t dsn_file_create_aio_task_ex(dsn_task_code_t code, dsn_aio_handler_t cb, 
+    dsn_task_cancelled_handler_t on_cancel,
+    void* context, int hash, dsn_task_tracker_t tracker)
+{
+    auto t = new ::dsn::aio_task(code, cb, context, on_cancel, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     return t;
 }

--- a/src/core/core/tool_api.cpp
+++ b/src/core/core/tool_api.cpp
@@ -46,7 +46,7 @@ namespace dsn {
     {
     public:
         service_control_task(service_node* node, bool start, bool cleanup = false)
-            : _node(node), task(LPC_CONTROL_SERVICE_APP, 0, node), _start(start), _cleanup(cleanup)
+            : _node(node), task(LPC_CONTROL_SERVICE_APP, nullptr, nullptr, 0, node), _start(start), _cleanup(cleanup)
         {
         }
 

--- a/src/core/tests/hpc_io_looper.cpp
+++ b/src/core/tests/hpc_io_looper.cpp
@@ -169,7 +169,7 @@ TEST(tools_hpc, io_looper_timer)
 
     int* a = new int;
     *a = 1;
-    dsn::task_c* t = new dsn::task_c(LPC_AIO_TEST, timer_callback, a);
+    dsn::task_c* t = new dsn::task_c(LPC_AIO_TEST, timer_callback, a, nullptr);
     t->add_ref();
 
     t->set_delay(1000);

--- a/src/core/tests/netprovider.cpp
+++ b/src/core/tests/netprovider.cpp
@@ -95,7 +95,7 @@ void rpc_client_session_send(rpc_session_ptr client_session)
     ::marshall(msg, std::string(buffer));
 
     wait_flag = 0;
-    rpc_response_task* t = new rpc_response_task(msg, response_handler, buffer);
+    rpc_response_task* t = new rpc_response_task(msg, response_handler, buffer, nullptr);
 
     client_session->net().engine()->matcher()->on_call(msg, t);
     client_session->send_message(msg);
@@ -176,7 +176,7 @@ TEST(tools_common, asio_udp_provider)
     ::marshall(msg, std::string(buffer));
 
     wait_flag = 0;
-    rpc_response_task* t = new rpc_response_task(msg, response_handler, buffer);
+    rpc_response_task* t = new rpc_response_task(msg, response_handler, buffer, nullptr);
 
     client->engine()->matcher()->on_call(msg, t);
     client->send_message(msg);

--- a/src/dev/cpp/clientlet.cpp
+++ b/src/dev/cpp/clientlet.cpp
@@ -120,12 +120,17 @@ namespace dsn
             tsk->add_ref(); // released in exec callback
             if (timer_interval_milliseconds != 0)
             {
-                t = dsn_task_create_timer(evt, safe_task<task_handler>::exec,
+                t = dsn_task_create_timer_ex(evt, 
+                    safe_task<task_handler>::exec,
+                    safe_task<task_handler>::on_cancel,
                     tsk, hash, timer_interval_milliseconds, svc ? svc->tracker() : nullptr);
             }
             else
             {
-                t = dsn_task_create(evt, safe_task<task_handler>::exec, tsk, hash, svc ? svc->tracker() : nullptr);
+                t = dsn_task_create_ex(evt, 
+                    safe_task<task_handler>::exec, 
+                    safe_task<task_handler>::on_cancel, 
+                    tsk, hash, svc ? svc->tracker() : nullptr);
             }
 
             tsk->set_task_info(t);
@@ -151,9 +156,10 @@ namespace dsn
             if (callback != nullptr)
                 tsk->add_ref(); // released in exec_rpc_response
 
-            auto t = dsn_rpc_create_response_task(
+            auto t = dsn_rpc_create_response_task_ex(
                 request,
                 callback != nullptr ? safe_task<rpc_reply_handler >::exec_rpc_response : nullptr,
+                safe_task<rpc_reply_handler >::on_cancel,
                 (void*)tsk,
                 reply_hash,
                 svc ? svc->tracker() : nullptr
@@ -183,8 +189,9 @@ namespace dsn
             if (callback != nullptr)
                 tsk->add_ref(); // released in exec_aio
 
-            dsn_task_t t = dsn_file_create_aio_task(callback_code,
+            dsn_task_t t = dsn_file_create_aio_task_ex(callback_code,
                 callback != nullptr ? safe_task<aio_handler>::exec_aio : nullptr,
+                safe_task<aio_handler>::on_cancel,
                 tsk, hash, svc ? svc->tracker() : nullptr
                 );
 
@@ -210,8 +217,9 @@ namespace dsn
             if (callback != nullptr)
                 tsk->add_ref(); // released in exec_aio
 
-            dsn_task_t t = dsn_file_create_aio_task(callback_code,
+            dsn_task_t t = dsn_file_create_aio_task_ex(callback_code,
                 callback != nullptr ? safe_task<aio_handler>::exec_aio : nullptr,
+                safe_task<aio_handler>::on_cancel,
                 tsk, hash, svc ? svc->tracker() : nullptr
                 );
 
@@ -236,8 +244,9 @@ namespace dsn
             if (callback != nullptr)
                 tsk->add_ref(); // released in exec_aio
 
-            dsn_task_t t = dsn_file_create_aio_task(callback_code,
+            dsn_task_t t = dsn_file_create_aio_task_ex(callback_code,
                 callback != nullptr ? safe_task<aio_handler>::exec_aio : nullptr,
+                safe_task<aio_handler>::on_cancel,
                 tsk, hash, svc ? svc->tracker() : nullptr
                 );
 
@@ -264,8 +273,9 @@ namespace dsn
             if (callback != nullptr)
                 tsk->add_ref(); // released in exec_aio
 
-            dsn_task_t t = dsn_file_create_aio_task(callback_code,
+            dsn_task_t t = dsn_file_create_aio_task_ex(callback_code,
                 callback != nullptr ? safe_task<aio_handler>::exec_aio : nullptr,
+                safe_task<aio_handler>::on_cancel,
                 tsk, hash, svc ? svc->tracker() : nullptr
                 );
 

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ -n "$DSN_ROOT"]
+then
+    export DSN_ROOT=`pwd`/install
+    echo export DSN_ROOT=$DSN_ROOT >> ~/.bashrc
+    echo export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$DSN_ROOT/lib >> ~/.bashrc
+    echo "================ THIS IS THE FIRST TIME REGISTER \$DSN_ROOT, please run source ~/.bashrc =========="
+fi
+
 CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_BUILD_TYPE=Debug"
 CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
 CMAKE_OPTIONS="$CMAKE_OPTIONS -DDSN_DEBUG_CMAKE=TRUE"
@@ -13,9 +21,9 @@ CMAKE_OPTIONS="$CMAKE_OPTIONS -DDSN_DEBUG_CMAKE=TRUE"
 #   cd boost_1_54_0
 #   ./bootstrap.sh --with-libraries=system,filesystem --with-toolset=gcc
 #   ./b2 toolset=gcc cxxflags="-std=c++11 -fPIC" -j8 -d0
-#   ./b2 install --prefix=`pwd`/output -d0
+#   ./b2 install --prefix=$DSN_ROOT -d0
 # And set BOOST_DIR as:
-#   export BOOST_DIR=/path/to/boost_1_54_0/output
+#   export BOOST_DIR=/path/to/boost_1_54_0/ouput
 if [ -n "$BOOST_DIR" ]
 then
     echo "Use customized boost: $BOOST_DIR"
@@ -59,7 +67,7 @@ then
     echo "Running cmake..."
     mkdir -p builder
     cd builder
-    cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/output $CMAKE_OPTIONS
+    cmake .. -DCMAKE_INSTALL_PREFIX=$DSN_ROOT $CMAKE_OPTIONS
     if [ $? -ne 0 ]
     then
         echo "cmake failed"


### PR DESCRIPTION
… when safe tasks are cancelled by task-tracker which does not explicitly call safe_task::cancel

fix issue https://github.com/imzhenyu/rDSN/issues/34
