### PR TITLE
fix meta_service to avoid coredump on starting & add test case

### DIFF
--- a/include/dsn/dist/replication/meta_service_app.h
+++ b/include/dsn/dist/replication/meta_service_app.h
@@ -62,7 +62,6 @@ namespace dsn {
         private:
             friend class ::dsn::replication::replication_checker;
             friend class ::dsn::replication::test::test_checker;
-            server_state*        _state;
             meta_service*        _service;
         };
 

--- a/src/apps/replication/exe/CMakeLists.txt
+++ b/src/apps/replication/exe/CMakeLists.txt
@@ -30,6 +30,8 @@ set(INI_FILES "")
 file(GLOB
     INI_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.ini"
+    "${CMAKE_CURRENT_SOURCE_DIR}/run.sh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/clear.sh"
     )
 
 # Extra files that will be installed

--- a/src/apps/replication/exe/clear.sh
+++ b/src/apps/replication/exe/clear.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf data core* out
+

--- a/src/apps/replication/exe/run.sh
+++ b/src/apps/replication/exe/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ ! -f dsn.replication.simple_kv ]; then
+    echo "dsn.replication.simple_kv not exist"
+    exit -1
+fi
+
+./clear.sh
+
+echo "running dsn.replication.simple_kv for 30 seconds ..."
+./dsn.replication.simple_kv config.ini &>out &
+PID=$!
+sleep 30
+kill $PID
+
+if [ -f core ] || ! grep ERR_OK out; then
+    echo "run dsn.replication.simple_kv failed"
+    echo "---- ls ----"
+    ls -l
+    echo "---- tail -n 100 out ----"
+    tail -n 100 out
+    if find . -name log.1.txt; then
+        echo "---- tail -n 100 log.1.txt ----"
+        tail -n 100 `find . -name log.1.txt`
+    fi
+    if [ -f core ]; then
+        echo "---- gdb ./dsn.replication.simple_kv core ----"
+        gdb ./dsn.replication.simple_kv core -ex "thread apply all bt" -ex "set pagination 0" -batch
+    fi
+    exit -1
+fi
+
+echo "run dsn.replication.simple_kv succeed"
+

--- a/src/apps/replication/global_checker/checker.cpp
+++ b/src/apps/replication/global_checker/checker.cpp
@@ -135,13 +135,13 @@ namespace dsn {
 
             void single_primary()
             {
-                auto meta = meta_leader();
-                if (!meta) return;
+                meta_service_app* meta_app = meta_leader();
+                if (!meta_app) return;
 
                 std::unordered_map<global_partition_id, ::dsn::rpc_address> primaries_from_meta_server;
                 std::unordered_map<global_partition_id, ::dsn::rpc_address> primaries_from_replica_servers;
 
-                for (auto& app : meta->_state->_apps)
+                for (auto& app : meta_app->_service->_state->_apps)
                 {
                     for (int i = 0; i < app.partition_count; i++)
                     {

--- a/src/apps/replication/meta_server/meta_service.h
+++ b/src/apps/replication/meta_server/meta_service.h
@@ -69,6 +69,8 @@ public:
     const char* cluster_root() const { return _cluster_root.c_str(); }
 
 private:
+    void register_rpc_handlers();
+
     // partition server & client => meta server
     // query partition configuration
     void on_query_configuration_by_node(dsn_message_t req);

--- a/src/apps/replication/meta_server/meta_service.h
+++ b/src/apps/replication/meta_server/meta_service.h
@@ -59,10 +59,10 @@ namespace dsn {
 class meta_service : public serverlet<meta_service>
 {
 public:
-    meta_service(const char* work_dir);
-    ~meta_service();
+    meta_service();
+    virtual ~meta_service();
 
-    error_code start();
+    error_code start(const char* work_dir);
     void stop();
 
     const char* work_dir() const { return _work_dir.c_str(); }

--- a/src/apps/replication/meta_server/meta_service_app.cpp
+++ b/src/apps/replication/meta_server/meta_service_app.cpp
@@ -66,6 +66,9 @@ namespace dsn {
 
         meta_service_app::meta_service_app()
         {
+            // create in constructor because it may be used in checker before started
+            _service = new meta_service();
+
             register_component_provider(
                 "distributed_lock_service_simple",
                 ::dsn::dist::distributed_lock_service::create<dsn::dist::distributed_lock_service_simple>
@@ -97,8 +100,7 @@ namespace dsn {
 
         ::dsn::error_code meta_service_app::start(int /*argc*/, char** /*argv*/)
         {
-            _service = new meta_service(dsn_get_current_app_data_dir());
-            return _service->start();
+            return _service->start(dsn_get_current_app_data_dir());
         }
 
         void meta_service_app::stop(bool /*cleanup*/)

--- a/src/apps/replication/meta_server/server_state.h
+++ b/src/apps/replication/meta_server/server_state.h
@@ -72,7 +72,7 @@ class server_state :
 {
 public:
     server_state();
-    ~server_state();
+    virtual ~server_state();
 
     // initialize server state
     error_code initialize(const char* work_dir, const char* cluster_root);

--- a/src/core/tests/run.sh
+++ b/src/core/tests/run.sh
@@ -9,8 +9,8 @@ for test_case in `ls config-test*.ini`; do
         echo "---- ls ----"
         ls -l
         if find . -name log.1.txt; then
-            echo "---- tail -n 200 log.1.txt ----"
-            tail -n 200 `find . -name log.1.txt`
+            echo "---- tail -n 100 log.1.txt ----"
+            tail -n 100 `find . -name log.1.txt`
         fi
         if [ -f core ]; then
             echo "---- gdb ./dsn.core.tests core ----"

--- a/src/rep_tests/simple_kv/checker.cpp
+++ b/src/rep_tests/simple_kv/checker.cpp
@@ -81,7 +81,7 @@ bool test_checker::init(const char* name, dsn_app_info* info, int count)
         if (0 == strcmp(app.type, "meta"))
         {
             meta_service_app* meta_app = (meta_service_app*)app.app_context_ptr;
-            meta_app->_state->set_config_change_subscriber_for_test(
+            meta_app->_service->_state->set_config_change_subscriber_for_test(
                         std::bind(&test_checker::on_config_change, this, std::placeholders::_1));
             _meta_servers.push_back(meta_app);
         }
@@ -219,7 +219,7 @@ bool test_checker::get_current_config(parti_config& config)
     if (meta == nullptr)
         return false;
     partition_configuration c;
-    meta->_state->query_configuration_by_gpid(g_default_gpid, c);
+    meta->_service->_state->query_configuration_by_gpid(g_default_gpid, c);
     config.convert_from(c);
     return true;
 }

--- a/src/rep_tests/simple_kv/clear.sh
+++ b/src/rep_tests/simple_kv/clear.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-rm -rf core* log.* m r1 r2 r3
+rm -rf data core*
 

--- a/src/rep_tests/simple_kv/run.sh
+++ b/src/rep_tests/simple_kv/run.sh
@@ -8,15 +8,19 @@ function run_single()
     echo "${bin} ${prefix}.ini ${prefix}.act"
     ${bin} ${prefix}.ini ${prefix}.act
     ret=$?
-    if [ -f log.1.txt ]; then
-        #mv log.1.txt ${prefix}.log
-        cat log.1.txt | grep -v FAILURE_DETECT | grep -v BEACON | grep -v beacon | grep -v THREAD_POOL_FD >${prefix}.log
-        rm log.1.txt
+    if find . -name log.1.txt; then
+        log=`find . -name log.1.txt`
+        cat ${log} | grep -v FAILURE_DETECT | grep -v BEACON | grep -v beacon | grep -v THREAD_POOL_FD >${prefix}.log
+        rm ${log}
     fi
 
     # successful case calls dsn_terminates which returns SIGKILL
     if [ ${ret} -ne 137 ]; then
         echo "run ${prefix} failed, return value = ${ret}"
+        if [ -f core ]; then
+            echo "---- gdb ./dsn.rep_tests.simple_kv core ----"
+            gdb ./dsn.rep_tests.simple_kv core -ex "thread apply all bt" -ex "set pagination 0" -batch
+        fi
         exit -1
     fi
 }

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -7,8 +7,8 @@ if [ $? -ne 0 ]; then
     echo "---- ls ----"
     ls -l
     if find . -name log.1.txt; then
-        echo "---- tail -n 200 log.1.txt ----"
-        tail -n 200 `find . -name log.1.txt`
+        echo "---- tail -n 100 log.1.txt ----"
+        tail -n 100 `find . -name log.1.txt`
     fi
     if [ -f core ]; then
         echo "---- gdb ./dsn.tests core ----"

--- a/test.sh
+++ b/test.sh
@@ -37,10 +37,12 @@ ROOT=`pwd`
 ##  - dsn.core.tests
 ##  - dsn.tests
 ##  - dsn.rep_tests.simple_kv
+##  - dsn.replication.simple_kv
 ##############################################
 TEST_MODULE='
 dsn.core.tests
 dsn.tests
+dsn.replication.simple_kv
 '
 
 # if clear


### PR DESCRIPTION
- fix meta_service to avoid coredump on starting when used by checker
- add dsn.replication.simple_kv into tests to run on travis
