### PR TITLE
fix bugs of failure detector

### DIFF
--- a/src/apps/replication/lib/replication_failure_detector.cpp
+++ b/src/apps/replication/lib/replication_failure_detector.cpp
@@ -122,8 +122,9 @@ void replication_failure_detector::end_ping(::dsn::error_code err, const fd::bea
             else
             {
                 ddebug("update meta server leader to [%s]", ack.this_node.to_string());
-                switch_master( dsn_group_get_leader(_meta_servers.group_handle()), ack.this_node.c_addr() );
+                rpc_address old_leader = dsn_group_get_leader(_meta_servers.group_handle());
                 dsn_group_set_leader(_meta_servers.group_handle(), ack.this_node.c_addr());
+                switch_master(old_leader, ack.this_node.c_addr() );
             }
         }
     }

--- a/src/apps/replication/lib/replication_failure_detector.cpp
+++ b/src/apps/replication/lib/replication_failure_detector.cpp
@@ -122,6 +122,7 @@ void replication_failure_detector::end_ping(::dsn::error_code err, const fd::bea
             else
             {
                 ddebug("update meta server leader to [%s]", ack.this_node.to_string());
+                switch_master( dsn_group_get_leader(_meta_servers.group_handle()), ack.this_node.c_addr() );
                 dsn_group_set_leader(_meta_servers.group_handle(), ack.this_node.c_addr());
             }
         }

--- a/src/dist/failure_detector/failure_detector.cpp
+++ b/src/dist/failure_detector/failure_detector.cpp
@@ -214,8 +214,13 @@ void failure_detector::process_all_records()
                 }
             }
 
+            /*
+             * "Check interval" and "send beacon" are interleaved, so we must
+             * test if "record will expire before next time we check all the records"
+             * in order to guarantee the perfect fd
+             */
             if (record.is_alive
-                && now - record.last_send_time_for_beacon_with_ack >= _lease_milliseconds)
+                && now + _check_interval_milliseconds - record.last_send_time_for_beacon_with_ack > _lease_milliseconds)
             {
                 expire.push_back(record.node);
                 record.is_alive = false;


### PR DESCRIPTION
1. add "switch_master" when beacon_ack is not the leader
2. bug fix in "process_all_records"
