### PR TITLE
CLI command register api change; added metaserver/replica CLI command; some bugfix

### DIFF
--- a/include/dsn/cpp/json_helper.h
+++ b/include/dsn/cpp/json_helper.h
@@ -1,0 +1,173 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ * 
+ * -=- Robust Distributed System Nucleus (rDSN) -=- 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Description:
+ *     helper for json serialization
+ *
+ * Revision history:
+ *     Dec., 2015, @Tianyi Wang, first version
+ */
+
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include "autoref_ptr.h"
+
+#define JSON_DICT_ENTRY(out, prefix, T) out << "\""#T"\":"; json_forwarder<std::decay<decltype((prefix).T)>::type>::call(out, (prefix).T)
+#define JSON_DICT_ENTRIES2(out, prefix, T1, T2) JSON_DICT_ENTRY(out, prefix, T1); out << ","; JSON_DICT_ENTRY(out, prefix, T2)
+#define JSON_DICT_ENTRIES3(out, prefix, T1, T2, T3) JSON_DICT_ENTRIES2(out, prefix, T1, T2); out << ","; JSON_DICT_ENTRY(out, prefix, T3)
+#define JSON_DICT_ENTRIES4(out, prefix, T1, T2, T3, T4) JSON_DICT_ENTRIES3(out, prefix, T1, T2, T3); out << ","; JSON_DICT_ENTRY(out, prefix, T4)
+#define JSON_DICT_ENTRIES5(out, prefix, T1, T2, T3, T4, T5) JSON_DICT_ENTRIES4(out, prefix, T1, T2, T3, T4); out << ","; JSON_DICT_ENTRY(out, prefix, T5)
+#define JSON_DICT_ENTRIES6(out, prefix, T1, T2, T3, T4, T5, T6) JSON_DICT_ENTRIES5(out, prefix, T1, T2, T3, T4, T5); out << ","; JSON_DICT_ENTRY(out, prefix, T6)
+#define JSON_DICT_ENTRIES7(out, prefix, T1, T2, T3, T4, T5, T6, T7) JSON_DICT_ENTRIES6(out, prefix, T1, T2, T3, T4, T5, T6); out << ","; JSON_DICT_ENTRY(out, prefix, T7)
+#define JSON_DICT_ENTRIES8(out, prefix, T1, T2, T3, T4, T5, T6, T7, T8) JSON_DICT_ENTRIES7(out, prefix, T1, T2, T3, T4, T5, T6, T7); out << ","; JSON_DICT_ENTRY(out, prefix, T8)
+
+#define JSON_ENTRIES_GET_MACRO(ph1,ph2,ph3,ph4,ph5,ph6,ph7,ph8, NAME, ...) NAME
+//workaround due to the way VC handles "..."
+#define JSON_ENTRIES_GET_MACRO_(tuple) JSON_ENTRIES_GET_MACRO tuple
+#define JSON_DICT_ENTRIES(out, prefix, ...) out<<"{";JSON_ENTRIES_GET_MACRO_((__VA_ARGS__, JSON_DICT_ENTRIES8, JSON_DICT_ENTRIES7, JSON_DICT_ENTRIES6, JSON_DICT_ENTRIES5, JSON_DICT_ENTRIES4, JSON_DICT_ENTRIES3, JSON_DICT_ENTRIES2)) (out, prefix, __VA_ARGS__); out<<"}"
+
+//parameters: fields to be serialized
+#define DEFINE_JSON_SERIALIZATION(...) void json_state(std::stringstream& out) const {JSON_DICT_ENTRIES(out, *this, __VA_ARGS__);}
+    
+namespace dsn{ namespace replication{
+    
+template<typename T>
+struct json_forwarder {
+private:
+    //check if C has C.json_state(sstream&) function
+    template<typename C>
+    static auto check_json_state(C*)
+        -> typename std::is_same<decltype(std::declval<C>().json_state(std::declval<std::stringstream&>())), void>::type; 
+
+    template<typename>
+    static std::false_type check_json_state(...);
+
+    //check if C has C->json_state(sstream&) function
+    template<typename C>
+    static auto p_check_json_state(C*)
+        -> typename std::is_same<decltype(std::declval<C>()->json_state(std::declval<std::stringstream&>())),void>::type;
+
+    template<typename>
+    static std::false_type p_check_json_state(...);
+
+    typedef decltype(check_json_state<T>(0)) has_json_state;
+    typedef decltype(p_check_json_state<T>(0)) p_has_json_state;
+
+    //internal serialization
+    static void call_inner(std::stringstream&out, const T& t, std::true_type, std::false_type)
+    {
+        t.json_state(out);
+    }
+    //internal serialization
+    static void call_inner(std::stringstream&out, const T& t, std::false_type, std::true_type)
+    {
+        t->json_state(out);
+    }
+    //internal serialization
+    static void call_inner(std::stringstream&out, const T& t, std::true_type, std::true_type)
+    {
+        t->json_state(out);
+    }
+    //external serialization
+    static void call_inner(std::stringstream&out, const T& t, std::false_type, std::false_type)
+    {
+        json_encode(out, t);
+    }
+public:
+    static void call(std::stringstream&out, const T& t)
+    {
+        call_inner(out, t, has_json_state{}, p_has_json_state{});
+    }
+};
+
+template<typename T> inline void json_encode(std::stringstream& out, const T& t)
+{
+    out << t;
+}
+template<typename T> inline void json_encode_iterable(std::stringstream& out, const T& t)
+{
+    out << "[";
+    for (auto it = t.begin(); it != t.end(); ++it)
+    {
+        json_forwarder<typename std::decay < decltype(*it) > ::type>::call(out, *it);
+        if (std::next(it) != t.end())
+        {
+            out << ",";
+        }
+    }
+    out << "]";
+}
+template<typename T> inline void json_encode_map(std::stringstream& out, const T& t)
+{
+    out << "{";
+    for (auto it = t.begin(); it != t.end(); ++it)
+    {
+        json_forwarder<typename std::decay < decltype(it->first) > :: type>::call(out, it->first);
+        out << ":";
+        json_forwarder<typename std::decay < decltype(it->second) > ::type>::call(out, it->second);
+        if (std::next(it) != t.end())
+        {
+            out << ",";
+        }
+    }
+    out << "}";
+}
+template<typename T> inline void json_encode(std::stringstream& out, const std::vector<T>& t)
+{
+    json_encode_iterable(out, t);
+}
+template<typename T> inline void json_encode(std::stringstream& out, const std::set<T>& t)
+{
+    json_encode_iterable(out, t);
+}
+template<typename T1, typename T2> inline void json_encode(std::stringstream& out, const std::unordered_map<T1, T2>& t)
+{
+    json_encode_map(out, t);
+}
+
+template<typename T> inline void json_encode(std::stringstream& out, const dsn::ref_ptr<T>& t)
+{
+    json_encode(out, *t);
+}
+
+inline void json_encode(std::stringstream& out, const std::string& t)
+{
+    out << "\"" << t << "\"";
+}
+inline void json_encode(std::stringstream& out, const char* t)
+{
+    out << "\"" << t << "\"";
+}
+
+}
+}

--- a/include/dsn/dist/replication/replication.types.h
+++ b/include/dsn/dist/replication/replication.types.h
@@ -46,6 +46,7 @@
 
 # include <dsn/service_api_cpp.h>
 
+
 # ifdef DSN_NOT_USE_DEFAULT_SERIALIZATION
 
 # include <dsn/thrift_helper.h>

--- a/include/dsn/dist/replication/replication_other_types.h
+++ b/include/dsn/dist/replication/replication_other_types.h
@@ -43,6 +43,10 @@
 #define replication_OTHER_TYPES_H
 
 # include <dsn/cpp/autoref_ptr.h>
+# include <dsn/dist/replication/replication.types.h>
+# include <sstream>
+# include <dsn/cpp/json_helper.h>
+# include <dsn/internal/enum_helper.h>
 
 namespace dsn {
     namespace replication {
@@ -67,6 +71,61 @@ namespace dsn {
 
         class mutation_log;
         typedef dsn::ref_ptr<mutation_log> mutation_log_ptr;
+
+
+        ENUM_BEGIN(partition_status, PS_INVALID)
+            ENUM_REG(PS_INACTIVE)
+            ENUM_REG(PS_ERROR)
+            ENUM_REG(PS_PRIMARY)
+            ENUM_REG(PS_SECONDARY)
+            ENUM_REG(PS_POTENTIAL_SECONDARY)
+        ENUM_END(partition_status)
+
+        ENUM_BEGIN(learn_type, LT_NONE)
+            ENUM_REG(LT_CACHE)
+            ENUM_REG(LT_APP)
+            ENUM_REG(LT_LOG)
+        ENUM_END(learn_type)
+
+        ENUM_BEGIN(learner_status, Learning_INVALID)
+            ENUM_REG(LearningWithoutPrepare)
+            ENUM_REG(LearningWithPrepareTransient)
+            ENUM_REG(LearningWithPrepare)
+            ENUM_REG(LearningSucceeded)
+            ENUM_REG(LearningFailed)
+        ENUM_END(learner_status)
+
+        ENUM_BEGIN(config_type, CT_NONE)
+            ENUM_REG(CT_ASSIGN_PRIMARY)
+            ENUM_REG(CT_UPGRADE_TO_PRIMARY)
+            ENUM_REG(CT_ADD_SECONDARY)
+            ENUM_REG(CT_DOWNGRADE_TO_SECONDARY)
+            ENUM_REG(CT_DOWNGRADE_TO_INACTIVE)
+            ENUM_REG(CT_REMOVE)
+            ENUM_REG(CT_UPGRADE_TO_SECONDARY)
+        ENUM_END(config_type)
+
+        inline void json_encode(std::stringstream& out, const dsn::rpc_address& address)
+        {
+            out << "\"" << address.to_string() << "\"";
+        }
+        inline void json_encode(std::stringstream& out, const partition_configuration& config)
+        {
+            JSON_DICT_ENTRIES(out, config, app_type, gpid, ballot, max_replica_count, primary, secondaries, last_drops, last_committed_decree);
+        }
+        inline void json_encode(std::stringstream& out, const partition_status& status)
+        {
+            json_encode(out, enum_to_string(status));
+        }
+        inline void json_encode(std::stringstream& out, const replica_configuration& config)
+        {
+            JSON_DICT_ENTRIES(out, config, gpid, ballot, primary, status, learner_signature);
+        }
+        
+        inline void json_encode(std::stringstream& out, const global_partition_id& gpid)
+        {
+            JSON_DICT_ENTRIES(out, gpid, app_id, pidx);
+        }
     }
 } // namespace
 

--- a/include/dsn/dist/replication/replication_other_types.h
+++ b/include/dsn/dist/replication/replication_other_types.h
@@ -105,10 +105,6 @@ namespace dsn {
             ENUM_REG(CT_UPGRADE_TO_SECONDARY)
         ENUM_END(config_type)
 
-        inline void json_encode(std::stringstream& out, const dsn::rpc_address& address)
-        {
-            out << "\"" << address.to_string() << "\"";
-        }
         inline void json_encode(std::stringstream& out, const partition_configuration& config)
         {
             JSON_DICT_ENTRIES(out, config, app_type, gpid, ballot, max_replica_count, primary, secondaries, last_drops, last_committed_decree);
@@ -127,6 +123,12 @@ namespace dsn {
             JSON_DICT_ENTRIES(out, gpid, app_id, pidx);
         }
     }
+
+    inline void json_encode(std::stringstream& out, const dsn::rpc_address& address)
+    {
+        out << "\"" << address.to_string() << "\"";
+    }
+
 } // namespace
 
 #endif

--- a/include/dsn/dist/replication/replication_service_app.h
+++ b/include/dsn/dist/replication/replication_service_app.h
@@ -59,6 +59,9 @@ private:
     friend class ::dsn::replication::replication_checker;
     friend class ::dsn::replication::test::test_checker;
     replica_stub_ptr _stub;
+
+    static const char* replica_service_app_info(int argc, char** argv);
+    static void replica_service_app_info_free(const char* response);
 };
 
 }}

--- a/include/dsn/internal/command.h
+++ b/include/dsn/internal/command.h
@@ -42,17 +42,19 @@ namespace dsn {
     
     typedef std::function<std::string(const std::vector<std::string>&)> command_handler;
 
-    void register_command(
+    void* register_command(
         const std::vector<const char*>& commands, // commands, e.g., {"help", "Help", "HELP", "h", "H"}
         const char* help_one_line,
         const char* help_long,
         command_handler handler
         );
 
-    void register_command(
+    void* register_command(
         const char* command, // commands, e.g., "help"
         const char* help_one_line,
         const char* help_long,
         command_handler handler
         );
+
+    void deregister_command(void* cli_handle);
 }

--- a/src/apps/replication/client_lib/replication_ds.h
+++ b/src/apps/replication/client_lib/replication_ds.h
@@ -37,44 +37,6 @@
 
 # include <dsn/internal/enum_helper.h>
 # include <dsn/dist/replication/replication.types.h>
-
-namespace dsn {
-    namespace replication {
-
-        ENUM_BEGIN(partition_status, PS_INVALID)
-            ENUM_REG(PS_INACTIVE)
-            ENUM_REG(PS_ERROR)
-            ENUM_REG(PS_PRIMARY)
-            ENUM_REG(PS_SECONDARY)
-            ENUM_REG(PS_POTENTIAL_SECONDARY)
-        ENUM_END(partition_status)
-
-        ENUM_BEGIN(learn_type, LT_NONE)
-            ENUM_REG(LT_CACHE)
-            ENUM_REG(LT_APP)
-            ENUM_REG(LT_LOG)
-        ENUM_END(learn_type)
-
-        ENUM_BEGIN(learner_status, Learning_INVALID)
-            ENUM_REG(LearningWithoutPrepare)
-            ENUM_REG(LearningWithPrepareTransient)
-            ENUM_REG(LearningWithPrepare)
-            ENUM_REG(LearningSucceeded)
-            ENUM_REG(LearningFailed)
-        ENUM_END(learner_status)
-        
-        ENUM_BEGIN(config_type, CT_NONE)
-            ENUM_REG(CT_ASSIGN_PRIMARY)
-            ENUM_REG(CT_UPGRADE_TO_PRIMARY)
-            ENUM_REG(CT_ADD_SECONDARY)
-            ENUM_REG(CT_DOWNGRADE_TO_SECONDARY)
-            ENUM_REG(CT_DOWNGRADE_TO_INACTIVE)
-            ENUM_REG(CT_REMOVE)
-            ENUM_REG(CT_UPGRADE_TO_SECONDARY)
-        ENUM_END(config_type)
-    }
-} // end namespace dsn::replication
-
 namespace std
 {
     template<>

--- a/src/apps/replication/lib/mutation_log.cpp
+++ b/src/apps/replication/lib/mutation_log.cpp
@@ -1454,7 +1454,7 @@ std::shared_ptr<log_block> log_file::prepare_log_block() const
     dassert(hdr->local_offset == static_cast<uint32_t>(offset - start_offset()), "");
     dassert(block.size() != 0, "log_block cannot be empty");
 
-    hdr->length = block.size() - sizeof(log_block_header);
+    hdr->length = static_cast<int32_t>(block.size() - sizeof(log_block_header));
     hdr->body_crc = _crc32;
     for (auto log_iter = std::next(block.data().begin()) ; log_iter != block.data().end(); ++ log_iter)
     {
@@ -1478,7 +1478,7 @@ std::shared_ptr<log_block> log_file::prepare_log_block() const
     task_ptr task = file::write_vector(
         _handle,
         buffer_vector.get(),
-        block.data().size(),
+        static_cast<int>(block.data().size()),
         static_cast<int>(offset - start_offset()),
         evt,
         callback_host,

--- a/src/apps/replication/lib/replica.cpp
+++ b/src/apps/replication/lib/replica.cpp
@@ -37,6 +37,7 @@
 #include "mutation.h"
 #include "mutation_log.h"
 #include "replica_stub.h"
+#include <dsn/cpp/json_helper.h>
 
 # ifdef __TITLE__
 # undef __TITLE__
@@ -78,6 +79,11 @@ replica::replica(replica_stub* stub, global_partition_id gpid, const char* app_t
 
     init_state();
     _config.gpid = gpid;
+}
+
+void replica::json_state(std::stringstream& out) const
+{
+    JSON_DICT_ENTRIES(out, *this, name(), _config, _app->last_committed_decree(), _app->last_durable_decree());
 }
 
 void replica::init_state()
@@ -380,8 +386,6 @@ void replica::close()
     if (_app != nullptr)
     {
         _app->close(false);
-        delete _app;
-        _app = nullptr;
     }
 }
 

--- a/src/apps/replication/lib/replica.h
+++ b/src/apps/replication/lib/replica.h
@@ -118,7 +118,7 @@ public:
     ballot get_ballot() const {return _config.ballot; }    
     partition_status status() const { return _config.status; }
     global_partition_id get_gpid() const { return _config.gpid; }    
-    replication_app_base* get_app() { return _app; }
+    replication_app_base* get_app() { return _app.get(); }
     decree max_prepared_decree() const { return _prepare_list->max_decree(); }
     decree last_committed_decree() const { return _prepare_list->last_committed_decree(); }
     decree last_prepared_decree() const;
@@ -128,6 +128,8 @@ public:
     uint64_t last_config_change_time_milliseconds() const { return _last_config_change_time_ms; }
     const char* name() const { return _name; }
     mutation_log_ptr private_log() const { return _private_log; }
+
+    void json_state(std::stringstream& out) const;
         
 private:
     // common helpers
@@ -222,7 +224,7 @@ private:
     dsn::task_ptr           _check_timer;
 
     // application
-    replication_app_base*   _app;
+    std::unique_ptr<replication_app_base>  _app;
 
     // constants
     replica_stub*           _stub;
@@ -236,4 +238,5 @@ private:
     potential_secondary_context _potential_secondary_states;
     bool                        _inactive_is_transient; // upgrade to P/S is allowed only iff true
 };
+
 }} // namespace

--- a/src/apps/replication/lib/replica_init.cpp
+++ b/src/apps/replication/lib/replica_init.cpp
@@ -162,7 +162,7 @@ error_code replica::init_app_and_prepare_list(const char* app_type, bool create_
 
     sprintf(_name, "%u.%u @ %s", _config.gpid.app_id, _config.gpid.pidx, primary_address().to_string());
 
-    _app = ::dsn::utils::factory_store<replication_app_base>::create(app_type, PROVIDER_TYPE_MAIN, this);
+    _app.reset(::dsn::utils::factory_store<replication_app_base>::create(app_type, PROVIDER_TYPE_MAIN, this));
     if (nullptr == _app)
     {
         return ERR_OBJECT_NOT_FOUND;
@@ -271,7 +271,6 @@ error_code replica::init_app_and_prepare_list(const char* app_type, bool create_
     {
         derror( "%s: open replica failed, error = %s", name(), err.to_string());
         _app->close(false);
-        delete _app;
         _app = nullptr;
     }
     

--- a/src/apps/replication/lib/replica_stub.h
+++ b/src/apps/replication/lib/replica_stub.h
@@ -124,7 +124,12 @@ public:
     replica_ptr get_replica(int32_t app_id, int32_t partition_index);
     replication_options& options() { return _options; }
     bool is_connected() const { return NS_Connected == _state; }
-    
+
+    void json_state(std::stringstream& out) const;
+    static void static_replica_stub_json_state(void* context, int argc, const char** argv, dsn_cli_reply* reply);
+
+    static void static_replica_stub_json_state_freer(dsn_cli_reply reply);
+
 private:    
     enum replica_node_state
     {
@@ -154,7 +159,7 @@ private:
     typedef std::unordered_map<global_partition_id, ::dsn::task_ptr> opening_replicas;
     typedef std::unordered_map<global_partition_id, std::pair< ::dsn::task_ptr, replica_ptr>> closing_replicas; // <close, replica>
 
-    zlock                       _replicas_lock;
+    mutable zlock               _replicas_lock;
     replicas                    _replicas;
     opening_replicas            _opening_replicas;
     closing_replicas            _closing_replicas;
@@ -175,6 +180,9 @@ private:
     ::dsn::task_ptr _config_query_task;
     ::dsn::task_ptr _config_sync_timer_task;
     ::dsn::task_ptr _gc_timer_task;
+
+    //cli handle, for deregister cli command
+    dsn_handle_t    _cli_replica_stub_json_state_handle;
 
 private:    
     friend class replica;

--- a/src/apps/replication/lib/replication_service_app.cpp
+++ b/src/apps/replication/lib/replication_service_app.cpp
@@ -70,6 +70,7 @@ error_code replication_service_app::start(int argc, char** argv)
 
     _stub->initialize(opts);
     _stub->open_service();
+
     return ERR_OK;
 }
 

--- a/src/apps/replication/meta_server/meta_server_failure_detector.cpp
+++ b/src/apps/replication/meta_server/meta_server_failure_detector.cpp
@@ -78,7 +78,7 @@ meta_server_failure_detector::meta_server_failure_detector(server_state* state, 
         distributed_lock_service_type,
         PROVIDER_TYPE_MAIN
         );
-    error_code err = _lock_svc->initialize(argc, &args_ptr[0]);
+    error_code err = _lock_svc->initialize(argc, argc > 0 ? &args_ptr[0] : nullptr);
     dassert(err == ERR_OK, "init distributed_lock_service failed, err = %s", err.to_string());
     _primary_lock_id = "dsn.meta.server.leader";
     _local_owner_id = primary_address().to_string();

--- a/src/apps/replication/meta_server/meta_service.cpp
+++ b/src/apps/replication/meta_server/meta_service.cpp
@@ -69,11 +69,11 @@ error_code meta_service::start()
     }
     ddebug("init server state succeed");
 
+    _failure_detector = new meta_server_failure_detector(_state, this);
     // should register rpc handlers before acquiring leader lock, so that this meta service
     // can tell others who is the current leader
     register_rpc_handlers();
-
-    _failure_detector = new meta_server_failure_detector(_state, this);
+    
     // become leader
     _failure_detector->acquire_leader_lock();
     dassert(_failure_detector->is_primary(), "must be primary at this point");
@@ -222,7 +222,7 @@ void meta_service::on_query_configuration_by_node(dsn_message_t msg)
 
 void meta_service::on_query_configuration_by_index(dsn_message_t msg)
 {
-    if (_failure_detector == nullptr || !check_primary(msg))
+    if (!check_primary(msg))
         return;
 
     if (!_started)

--- a/src/apps/replication/meta_server/meta_service.cpp
+++ b/src/apps/replication/meta_server/meta_service.cpp
@@ -222,7 +222,7 @@ void meta_service::on_query_configuration_by_node(dsn_message_t msg)
 
 void meta_service::on_query_configuration_by_index(dsn_message_t msg)
 {
-    if (!check_primary(msg))
+    if (_failure_detector == nullptr || !check_primary(msg))
         return;
 
     if (!_started)

--- a/src/apps/replication/meta_server/server_state.cpp
+++ b/src/apps/replication/meta_server/server_state.cpp
@@ -125,7 +125,7 @@ error_code server_state::initialize()
         meta_state_service_type,
         PROVIDER_TYPE_MAIN
         );
-    error_code err = _storage->initialize(argc, &args_ptr[0]);
+    error_code err = _storage->initialize(argc, argc > 0 ? &args_ptr[0] : nullptr);
     if (err != ERR_OK)
     {
         derror("init meta_state_service failed, err = %s", err.to_string());

--- a/src/apps/replication/meta_server/server_state.cpp
+++ b/src/apps/replication/meta_server/server_state.cpp
@@ -1,4 +1,5 @@
 /*
+
  * The MIT License (MIT)
  *
  * Copyright (c) 2015 Microsoft Corporation
@@ -63,7 +64,7 @@ void unmarshall(binary_reader& reader, /*out*/ app_state& val)
 }
 
 server_state::server_state()
-    : ::dsn::serverlet<server_state>("meta.server.state")
+    : ::dsn::serverlet<server_state>("meta.server.state"), _cli_json_state_handle(nullptr)
 {
     _node_live_count = 0;
     _node_live_percentage_threshold_for_update = 65;
@@ -77,6 +78,11 @@ server_state::~server_state()
     {
         delete _storage;
         _storage = nullptr;
+    }
+    if (_cli_json_state_handle != nullptr)
+    {
+        dsn_cli_deregister(_cli_json_state_handle);
+        _cli_json_state_handle = nullptr;
     }
 }
 
@@ -147,6 +153,10 @@ error_code server_state::initialize()
         }
     }
     _cluster_root = current.empty() ? "/" : current;
+
+    dassert(_cli_json_state_handle == nullptr, "server state is initialized twice");
+    _cli_json_state_handle = dsn_cli_app_register("info", "get info of nodes and apps on meta_server", "", this, &static_cli_json_state, &static_cli_json_state_cleanup);
+    dassert(_cli_json_state_handle != nullptr, "register cil handler failed, maybe it has been registered");
 
     ddebug("init server_state succeed, cluster_root = %s", _cluster_root.c_str());
     return ERR_OK;
@@ -273,7 +283,7 @@ error_code server_state::initialize_apps()
     {
         _apps.push_back(app);
     }
-
+    
     return err;
 }
 
@@ -889,4 +899,29 @@ bool server_state::partition_configuration_equal(const partition_configuration& 
            pc1.primary == pc2.primary &&
            pc1.secondaries == pc2.secondaries &&
            pc1.last_committed_decree == pc2.last_committed_decree;
+}
+
+void server_state::json_state(std::stringstream& out) const
+{
+    zauto_read_lock _(_lock);
+    JSON_DICT_ENTRIES(out, *this, _nodes, _apps);
+}
+
+void server_state::static_cli_json_state(void* context, int argc, const char** argv, dsn_cli_reply* reply)
+{
+    auto _server_state = reinterpret_cast<server_state*>(context);
+    std::stringstream out;
+    _server_state->json_state(out);
+    auto danglingstring = new std::string(std::move(out.str()));
+    reply->message = danglingstring->c_str();
+    reply->size = danglingstring->size();
+    reply->context = danglingstring;
+}
+
+void server_state::static_cli_json_state_cleanup(dsn_cli_reply reply)
+{
+    dassert(reply.context != nullptr, "corrupted cli reply context");
+    auto danglingstring = reinterpret_cast<std::string*>(reply.context);
+    dassert(reply.message == danglingstring->c_str(), "corrupted cli reply message");
+    delete danglingstring;
 }

--- a/src/apps/replication/meta_server/server_state.h
+++ b/src/apps/replication/meta_server/server_state.h
@@ -35,9 +35,10 @@
 
 #pragma once
 
-#include "replication_common.h"
+# include "replication_common.h"
 # include <dsn/dist/meta_state_service.h>
-#include <set>
+# include <dsn/cpp/json_helper.h>
+# include <set>
 
 using namespace dsn;
 using namespace dsn::service;
@@ -61,13 +62,14 @@ struct app_state
     int32_t                              app_id;
     int32_t                              partition_count;
     std::vector<partition_configuration> partitions;
+    DEFINE_JSON_SERIALIZATION(app_type, app_name, app_id, partition_count, partitions);
 };
 
 typedef std::unordered_map<global_partition_id, std::shared_ptr<configuration_update_request> > machine_fail_updates;
 
 typedef std::function<void (const std::vector<app_state>& /*new_config*/)> config_change_subscriber;
 
-class server_state : 
+class server_state :
     public ::dsn::serverlet<server_state>
 {
 public:
@@ -88,7 +90,7 @@ public:
     //  * set node state from live to unlive, and returns configuration_update_request to apply
     //  * set node state from unlive to live, and leaves load balancer to update configuration
     void set_node_state(const node_states& nodes, /*out*/ machine_fail_updates* pris);
-    
+
     // partition server & client => meta server
 
     // query all partition configurations of a replica server
@@ -107,7 +109,7 @@ public:
     // TODO: callback should pass in error_code
     void update_configuration(
         std::shared_ptr<configuration_update_request>& req,
-        dsn_message_t request_msg, 
+        dsn_message_t request_msg,
         std::function<void()> callback
         );
 
@@ -118,8 +120,8 @@ public:
 
     // for test
     void set_config_change_subscriber_for_test(config_change_subscriber subscriber);
-    
-private:    
+
+private:
     // initialize apps in local cache and in remote storage
     error_code initialize_apps();
 
@@ -153,6 +155,7 @@ private:
         ::dsn::rpc_address            address;
         std::set<global_partition_id> primaries;
         std::set<global_partition_id> partitions;
+        DEFINE_JSON_SERIALIZATION(is_alive, address, primaries, partitions);
     };
 
     friend class load_balancer;
@@ -181,5 +184,12 @@ private:
 
     // for test
     config_change_subscriber          _config_change_subscriber;
+
+    dsn_handle_t                      _cli_json_state_handle;
+
+public:
+    void json_state(std::stringstream& out) const;
+    static void static_cli_json_state(void* context, int argc, const char** argv, dsn_cli_reply* reply);
+    static void static_cli_json_state_cleanup(dsn_cli_reply reply);
 };
 

--- a/src/apps/replication/meta_server/server_state.h
+++ b/src/apps/replication/meta_server/server_state.h
@@ -35,9 +35,9 @@
 
 #pragma once
 
+# include <dsn/dist/replication/replication_other_types.h>
 # include "replication_common.h"
 # include <dsn/dist/meta_state_service.h>
-# include <dsn/cpp/json_helper.h>
 # include <set>
 
 using namespace dsn;

--- a/src/core/core/command_manager.h
+++ b/src/core/core/command_manager.h
@@ -48,7 +48,8 @@ namespace dsn {
     public:
         command_manager();
 
-        void register_command(const std::vector<const char*>& commands, const char* help_one_line, const char* help_long, command_handler handler);
+        dsn_handle_t register_command(const std::vector<const char*>& commands, const char* help_one_line, const char* help_long, command_handler handler);
+        void deregister_command(dsn_handle_t handle);
         bool run_command(const std::string& cmdline, /*out*/ std::string& output);
         void run_console();
         void start_local_cli();

--- a/src/tests/mutation_log.cpp
+++ b/src/tests/mutation_log.cpp
@@ -39,7 +39,7 @@
 using namespace ::dsn;
 using namespace ::dsn::replication;
 
-static void copy_file(const char* from_file, const char* to_file, int to_size = -1)
+static void copy_file(const char* from_file, const char* to_file, int64_t to_size = -1)
 {
     int64_t from_size;
     ASSERT_TRUE(dsn::utils::filesystem::file_size(from_file, from_size));
@@ -53,7 +53,7 @@ static void copy_file(const char* from_file, const char* to_file, int to_size = 
     if (to_size > 0)
     {
         std::unique_ptr<char> buf(new char[to_size]);
-        int n = fread(buf.get(), 1, to_size, from);
+        auto n = fread(buf.get(), 1, to_size, from);
         ASSERT_EQ(to_size, n);
         n = fwrite(buf.get(), 1, to_size, to);
         ASSERT_EQ(to_size, n);


### PR DESCRIPTION
implemented #25 #38

Changed CLI register interface and added a deregister api. 
We can now use meta.info / replica#.info in CLI to get a JSON dump of their role/state/decree, etc.
Added a json_helper in cpp lib.
Fixed bugs in meta_server initialization.
