### PR TITLE
fix on meta_server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ dsn_add_pseudo_projects()
 
 add_subdirectory(ext/gtest)
 add_subdirectory(ext/zookeeper)
-
+add_subdirectory(ext/rapidjson)
 #
 # !!! gflags is currently not used, and when it is enabled, it causes failure on windows compilation
 # add_subdirectory(ext/gflags)

--- a/ext/rapidjson/CMakeLists.txt
+++ b/ext/rapidjson/CMakeLists.txt
@@ -1,0 +1,11 @@
+include(ExternalProject)
+
+ExternalProject_Add(rapidjson_header
+    GIT_REPOSITORY https://github.com/shengofsun/rapidjson-header.git
+    GIT_TAG master
+    INSTALL_COMMAND ""
+)
+
+# Specify source dir
+ExternalProject_Get_Property(rapidjson_header source_dir)
+set(RAPIDJSON_INCLUDE_DIR ${source_dir}/include PARENT_SCOPE)

--- a/include/dsn/dist/distributed_lock_service.h
+++ b/include/dsn/dist/distributed_lock_service.h
@@ -66,6 +66,10 @@ namespace dsn
             typedef std::function<void (error_code ec)> err_callback;
             typedef std::function<void (error_code ec, const std::string& owner_id, uint64_t version)> lock_callback;
 
+            struct lock_options {
+                bool create_if_not_exist;
+                bool create_enable_cache;
+            };
             /*
              * initialization routine
              */
@@ -98,11 +102,11 @@ namespace dsn
             virtual std::pair<task_ptr, task_ptr> lock(
                               const std::string& lock_id,
                               const std::string& myself_id,
-                              bool create_if_not_exist,
                               task_code lock_cb_code,
                               const lock_callback& lock_cb,
                               task_code lease_expire_code,
-                              const lock_callback& lease_expire_callback
+                              const lock_callback& lease_expire_callback, 
+                              const lock_options& opt
                               ) = 0;
             
             /*
@@ -158,6 +162,15 @@ namespace dsn
                                     const std::string& lock_id,
                                     task_code cb_code,
                                     const lock_callback& cb) = 0;
+            /*
+             * error_code: err_invalid_parameters -> if the lock is created without cache enabled
+             *             err_object_not_found -> no lock created with lock_id
+             *             err_ok -> query the cache successfully
+             */
+            virtual error_code query_cache(
+                const std::string& lock_id, 
+                std::string& owner, 
+                uint64_t& version) = 0;
         };
     }
 }

--- a/src/apps/replication/exe/CMakeLists.txt
+++ b/src/apps/replication/exe/CMakeLists.txt
@@ -32,6 +32,7 @@ file(GLOB
     "${CMAKE_CURRENT_SOURCE_DIR}/*.ini"
     "${CMAKE_CURRENT_SOURCE_DIR}/run.sh"
     "${CMAKE_CURRENT_SOURCE_DIR}/clear.sh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/multi-meta.sh"
     )
 
 # Extra files that will be installed

--- a/src/apps/replication/exe/config-zk.ini
+++ b/src/apps/replication/exe/config-zk.ini
@@ -183,6 +183,6 @@ log_enable_private_commit = false
 config_sync_interval_ms = 60000
 
 [zookeeper]
-hosts_list = localhost:2181
+hosts_list = localhost:12181
 timeout_ms = 30000
 logfile = zoo.log

--- a/src/apps/replication/exe/multi-meta.sh
+++ b/src/apps/replication/exe/multi-meta.sh
@@ -1,0 +1,49 @@
+exe=dsn.replication.simple_kv
+cfg=config-zk.ini
+
+function run_app()
+{
+    app_dir=$1$2
+    if [ ! -d $app_dir ]; then
+        mkdir $app_dir
+    fi
+    cp $exe $cfg $app_dir
+    cd $app_dir
+    ./$exe $cfg -app_list $1@$2 > output.log 2>&1 &
+    cd ..
+}
+
+function kill_app()
+{
+    ps aux | grep $exe | grep $cfg | grep $1@$2 | awk '{print $2}' | xargs kill -9
+}
+
+function start_all_apps()
+{
+    if [ ! -d run ]; then
+        mkdir run
+    fi
+    cp $exe $cfg run
+    cd run
+
+    for i in 1 2 3; do
+        run_app meta $i
+        run_app replica $i
+    done
+
+    cd ..
+}
+
+function stop_all_apps()
+{
+    ps aux | grep $exe | grep $cfg | awk '{print $2}' | xargs kill -9
+}
+
+case $1 in
+    start)
+        start_all_apps ;;
+    stop)
+        stop_all_apps ;;
+    clear)
+        rm -rf run ;;
+esac

--- a/src/apps/replication/meta_server/CMakeLists.txt
+++ b/src/apps/replication/meta_server/CMakeLists.txt
@@ -9,7 +9,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_INC_PATH ../client_lib ../../../dist/failure_detector)
+set(MY_PROJ_INC_PATH ../client_lib ../../../dist/failure_detector ${RAPIDJSON_INCLUDE_DIR})
 
 set(MY_PROJ_LIBS "")
 

--- a/src/apps/replication/meta_server/CMakeLists.txt
+++ b/src/apps/replication/meta_server/CMakeLists.txt
@@ -19,3 +19,4 @@ set(MY_PROJ_LIB_PATH "")
 set(MY_BINPLACES "")
 
 dsn_add_static_library()
+add_dependencies(${MY_PROJ_NAME} rapidjson_header)

--- a/src/apps/replication/meta_server/distributed_lock_service_simple.h
+++ b/src/apps/replication/meta_server/distributed_lock_service_simple.h
@@ -53,11 +53,11 @@ namespace dsn
             virtual std::pair<task_ptr, task_ptr> lock(
                 const std::string& lock_id,
                 const std::string& myself_id,
-                bool create_if_not_exist,
                 task_code lock_cb_code,
                 const lock_callback& lock_cb,
                 task_code lease_expire_code,
-                const lock_callback& lease_expire_callback
+                const lock_callback& lease_expire_callback, 
+                const lock_options& opt
                 ) override;
 
             virtual task_ptr cancel_pending_lock(
@@ -78,6 +78,10 @@ namespace dsn
                 task_code cb_code,
                 const lock_callback& cb) override;
 
+            virtual error_code query_cache(
+                const std::string& lock_id, 
+                std::string& owner, 
+                uint64_t& version) override;
         private:
             void random_lock_lease_expire(const std::string& lock_id);
 

--- a/src/apps/replication/meta_server/meta_server_failure_detector.cpp
+++ b/src/apps/replication/meta_server/meta_server_failure_detector.cpp
@@ -36,6 +36,7 @@
 #include "meta_server_failure_detector.h"
 #include "server_state.h"
 #include "meta_service.h"
+#include <dsn/dist/distributed_lock_service.h>
 #include <dsn/internal/factory_store.h>
 
 # ifdef __TITLE__
@@ -46,6 +47,7 @@
 meta_server_failure_detector::meta_server_failure_detector(server_state* state, meta_service* svc)
 {
     _is_primary = false;
+    _active_fd = false;
     _state = state;
     _svc = svc;
 
@@ -81,7 +83,6 @@ meta_server_failure_detector::meta_server_failure_detector(server_state* state, 
     error_code err = _lock_svc->initialize(argc, argc > 0 ? &args_ptr[0] : nullptr);
     dassert(err == ERR_OK, "init distributed_lock_service failed, err = %s", err.to_string());
     _primary_lock_id = "dsn.meta.server.leader";
-    _local_owner_id = primary_address().to_string();
 
     ddebug("init meta_server_failure_detector succeed");
 }
@@ -148,87 +149,37 @@ void meta_server_failure_detector::on_worker_connected(::dsn::rpc_address node)
 }
 
 DEFINE_TASK_CODE(LPC_META_SERVER_LEADER_LOCK_CALLBACK, TASK_PRIORITY_COMMON, THREAD_POOL_FD)
-DEFINE_TASK_CODE(LPC_CM_QUERY_LEADER_LOCK, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
-DEFINE_TASK_CODE(LPC_CM_QUERY_LEADER_LOCK_TIMER, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
 
 void meta_server_failure_detector::acquire_leader_lock()
 {
     //
-    // lets' first set up a timer to query the leader
-    // so as to tell other nodes who is the leader in case they query
-    //
-    int leader_lock_query_interval_seconds = (int)dsn_config_get_value_uint64(
-        "meta_server",
-        "leader_lock_query_interval_seconds",
-        5, // 5 seconds
-        "period (seconds) for meta server to query the leader before itself becomes the leader"
-        );
-
-    task_ptr query_leader_task;
-    task_ptr query_leader_timer = tasking::enqueue(
-        LPC_CM_QUERY_LEADER_LOCK_TIMER,
-        this,
-        [this, &query_leader_task]()
-        {
-            if (query_leader_task != nullptr)
-                return;
-
-            query_leader_task = _lock_svc->query_lock(
-                _primary_lock_id,
-                LPC_CM_QUERY_LEADER_LOCK,
-                [this, &query_leader_task](error_code ec, const std::string& owner_id, uint64_t version)
-                {
-                    if ( ec == ERR_OK )
-                    {
-                        rpc_address addr;
-                        if (addr.from_string_ipv4(owner_id.c_str()))
-                        {
-                            set_primary(addr);
-                        }
-                    }
-                    query_leader_task = nullptr;
-                }
-            );
-        },
-        0,
-        0,
-        leader_lock_query_interval_seconds * 1000
-        );
-        
-    //
     // try to get the leader lock until it is done
     //
+    dsn::dist::distributed_lock_service::lock_options opt = {true, true};
+    std::string local_owner_id;
     while (true)
     {
         error_code err;
         auto tasks =
             _lock_svc->lock(
             _primary_lock_id,
-            _local_owner_id,
-            true,
-
+            primary_address().to_std_string(), 
             // lock granted
             LPC_META_SERVER_LEADER_LOCK_CALLBACK,
-            [this, &err](error_code ec, const std::string& owner, uint64_t version)
-        {
-            err = ec;
-        },
+            [this, &err, &local_owner_id](error_code ec, const std::string& owner, uint64_t version)
+            {
+                err = ec;
+                local_owner_id = owner;
+            },
 
             // lease expire
             LPC_META_SERVER_LEADER_LOCK_CALLBACK,
             [this](error_code ec, const std::string& owner, uint64_t version)
-        {
-            // let's take the easy way right now
-            dsn_exit(0);
-
-            // reset primary
-            //rpc_address addr;
-            //set_primary(addr);
-            //_state->on_become_non_leader();
-
-            //// set another round of service
-            //acquire_leader_lock();            
-        }
+            {
+                // let's take the easy way right now
+                dsn_exit(0);
+            },
+            opt
         );
 
         _lock_grant_task = tasks.first;
@@ -238,19 +189,13 @@ void meta_server_failure_detector::acquire_leader_lock()
         if (err == ERR_OK)
         {
             rpc_address addr;
-            if (addr.from_string_ipv4(_local_owner_id.c_str()))
+            if (addr.from_string_ipv4(local_owner_id.c_str()))
             {
-                query_leader_timer->cancel(true);
-                query_leader_timer = nullptr;
-
-                task_ptr t = query_leader_task;
-                if (t != nullptr)
-                {
-                    t->cancel(true);
-                    query_leader_task = nullptr;
-                }
-
                 dassert(primary_address() == addr, "");
+                /* 
+                 * we don't do register worker things in set_primary
+                 * because currently all nodes in node_state is from failure_detector
+                 */
                 set_primary(addr);
                 break;
             }
@@ -267,17 +212,6 @@ void meta_server_failure_detector::set_primary(rpc_address primary)
         _is_primary = (primary == primary_address());
     }
 
-    if (!old && _is_primary)
-    {
-        node_states ns;
-        _state->get_node_state(ns);
-
-        for (auto& pr : ns)
-        {
-            register_worker(pr.first, pr.second);
-        }
-    }
-
     if (old && !_is_primary)
     {
         clear_workers();
@@ -289,24 +223,32 @@ void meta_server_failure_detector::on_ping(const fd::beacon_msg& beacon, ::dsn::
 {
     fd::beacon_ack ack;
     ack.this_node = beacon.to;
+    ack.time = beacon.time;
     ack.allowed = true;
 
-    if (!is_primary())
+    if ( !is_primary() )
     {
-        ack.time = beacon.time;
         ack.is_master = false;
-
-        {
-            utils::auto_lock<zlock> l(_primary_address_lock);
-            ack.primary_node = _primary_address;
-        }
+        ack.primary_node = get_primary();
     }
-    else
+    else 
     {
-        failure_detector::on_ping_internal(beacon, ack);
-        ack.primary_node = primary_address();
+        ack.primary_node = beacon.to;
+        ack.is_master = true;
+        /*
+         * _active_fd flag is disabled for this case:
+         *      1. the new master acquires the leader lock
+         *      2. but the server state has not been initliazed 
+         * 
+         * In this case, we need to response to worker's ping request. 
+         * To make life easier, we don't add it to our worker_list.
+         */
+        if ( _active_fd )
+            failure_detector::on_ping_internal(beacon, ack);
     }
 
+    dinfo("on_ping, is_master(%s), this_node(%s), primary_node(%s)", ack.is_master?"true":"false",
+          ack.this_node.to_string(), ack.primary_node.to_string());
     reply(ack);
 }
 

--- a/src/apps/replication/meta_server/meta_server_failure_detector.h
+++ b/src/apps/replication/meta_server/meta_server_failure_detector.h
@@ -68,10 +68,20 @@ public:
     virtual ~meta_server_failure_detector();
 
     bool is_primary() const { return _is_primary; }
-
+    void active_failure_detector() { _active_fd=true; }
     rpc_address get_primary()
     {
         dsn::utils::auto_lock<zlock> l(_primary_address_lock);
+        if ( _lock_svc!=nullptr && !_is_primary )
+        {
+            uint64_t version;
+            error_code ec = _lock_svc->query_cache(_primary_lock_id, _lock_owner_id, version);
+            dinfo("query cache result: err: %s, owner(%s), version(%llu)", ec.to_string(), _lock_owner_id.c_str(), version);
+            if (ec != ERR_OK)
+                _primary_address.set_invalid();
+            else
+                _primary_address.from_string_ipv4(_lock_owner_id.c_str());
+        }
         return _primary_address;
     }
     
@@ -96,13 +106,13 @@ public:
 
 private:
     void set_primary(rpc_address primary);
-    void query_leader_callback();
 
 private:
     friend class ::dsn::replication::replication_checker;
     friend class ::dsn::replication::test::test_checker;
 
     volatile bool _is_primary;
+    volatile bool _active_fd;
 
     zlock         _primary_address_lock;
     rpc_address   _primary_address;
@@ -114,6 +124,6 @@ private:
     task_ptr    _lock_grant_task;
     task_ptr    _lock_expire_task;
     std::string _primary_lock_id;
-    std::string _local_owner_id;
+    std::string _lock_owner_id;
 };
 

--- a/src/apps/replication/meta_server/meta_server_failure_detector.h
+++ b/src/apps/replication/meta_server/meta_server_failure_detector.h
@@ -63,10 +63,20 @@ public:
     virtual ~meta_server_failure_detector();
 
     bool is_primary() const { return _is_primary; }
-
+    void active_failure_detector() { _active_fd=true; }
     rpc_address get_primary()
     {
         dsn::utils::auto_lock<zlock> l(_primary_address_lock);
+        if ( !_is_primary ) 
+        {
+            uint64_t version;
+            error_code ec = _lock_svc->query_cache(_primary_lock_id, _lock_owner_id, version);
+            
+            if (ec != ERR_OK)
+                _primary_address.set_invalid();
+            else
+                _primary_address.from_string_ipv4(_lock_owner_id.c_str());
+        }
         return _primary_address;
     }
     
@@ -91,13 +101,13 @@ public:
 
 private:
     void set_primary(rpc_address primary);
-    void query_leader_callback();
 
 private:
     friend class ::dsn::replication::replication_checker;
     friend class ::dsn::replication::test::test_checker;
 
     volatile bool _is_primary;
+    volatile bool _active_fd;
 
     zlock         _primary_address_lock;
     rpc_address   _primary_address;
@@ -109,6 +119,6 @@ private:
     task_ptr    _lock_grant_task;
     task_ptr    _lock_expire_task;
     std::string _primary_lock_id;
-    std::string _local_owner_id;
+    std::string _lock_owner_id;
 };
 

--- a/src/apps/replication/meta_server/meta_service.cpp
+++ b/src/apps/replication/meta_server/meta_service.cpp
@@ -69,7 +69,21 @@ error_code meta_service::start()
     }
     ddebug("init server state succeed");
 
+    // we should start the FD service to response to the workers fd request
     _failure_detector = new meta_server_failure_detector(_state, this);
+    err = _failure_detector->start(
+        _opts.fd_check_interval_seconds,
+        _opts.fd_beacon_interval_seconds,
+        _opts.fd_lease_seconds,
+        _opts.fd_grace_seconds,
+        false
+    );
+    if (err != ERR_OK)
+    {
+        derror("start failure_detector failed, err = %s", err.to_string());
+        return err;
+    }
+    
     // should register rpc handlers before acquiring leader lock, so that this meta service
     // can tell others who is the current leader
     register_rpc_handlers();
@@ -81,23 +95,17 @@ error_code meta_service::start()
 
     // recover server state
     while ((err = _state->on_become_leader()) != ERR_OK)
-    {
         derror("recover server state failed, err = %s, retry ...");
-    }
-    ddebug("recover server state succeed");
 
-    err = _failure_detector->start(
-        _opts.fd_check_interval_seconds,
-        _opts.fd_beacon_interval_seconds,
-        _opts.fd_lease_seconds,
-        _opts.fd_grace_seconds,
-        false
-        );
-    if (err != ERR_OK)
-    {
-        derror("start failure_detector failed, err = %s", err.to_string());
-        return err;
+    ddebug("recover server state succeed, and start to register workers");
+    
+    node_states all_nodes;
+    _state->get_node_state(all_nodes);
+    for (auto& node: all_nodes) {
+        dassert(node.second, "we assume all nodes are alive");
+        _failure_detector->register_worker(node.first, node.second);
     }
+    _failure_detector->active_failure_detector();
 
     _balancer = new load_balancer(_state);
     // make sure the delay is larger than fd.grace to ensure

--- a/src/apps/replication/meta_server/server_state.cpp
+++ b/src/apps/replication/meta_server/server_state.cpp
@@ -40,6 +40,11 @@
 # include <cinttypes>
 # include <boost/lexical_cast.hpp>
 
+# include <rapidjson/document.h>
+# include <rapidjson/prettywriter.h>
+# include <rapidjson/writer.h>
+# include <rapidjson/stringbuffer.h>
+
 # ifdef __TITLE__
 # undef __TITLE__
 # endif
@@ -54,6 +59,97 @@ void marshall(binary_writer& writer, const app_state& val)
     marshall(writer, val.partitions);
 }
 
+/**
+ * app_state:
+ * {
+ *   "app_type": "whatever",
+ *   "app_id": 11,
+ *   "app_name": "you like",
+ *   "partition_count": 2323,
+ * }
+ */
+void marshall_json(blob& output, const app_state& app)
+{
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+    writer.StartObject();
+    writer.String("app_type"); writer.String(app.app_type.c_str());
+    writer.String("app_name"); writer.String(app.app_name.c_str());
+    writer.String("app_id"); writer.Int(app.app_id);
+    writer.String("partition_count"); writer.Int(app.partition_count);
+    writer.EndObject();
+
+    std::shared_ptr<char> outptr(new char[buffer.GetSize()], [](char* ptr){ delete []ptr; } );
+    memcpy(outptr.get(), buffer.GetString(), buffer.GetSize());
+    output.assign(outptr, 0, buffer.GetSize());
+}
+
+static const char* partition_status_str[] = {
+    "inactive", "error", "primary", "secondary",
+    "potential_secondary", "invalid", nullptr
+};
+const char* get_partition_status_string(partition_status ps)
+{
+    return partition_status_str[ps];
+}
+partition_status get_partition_status(const char* status_str)
+{
+    for (int i=0; partition_status_str[i]!=nullptr; ++i)
+        if (strcmp(partition_status_str[i], status_str)==0)
+            return (partition_status)i;
+    return PS_INVALID;
+}
+/**
+ * Example partition config:
+ * {"ballot": 1, "last_committed_decree": 2, "max_replica_count": 3,
+ *  "entries": [{"addr": "xxx.xxx.xxx.xxx:12345", "partition_status": "primary"},
+ *              {"addr": "xxx.xxx.xxx.xxb:23424", "partition_status": "secondary"}
+ *             ]}
+ * type of role: primary/secondary/potential primary/potential secondary/inactive
+ **/
+void marshall_json(blob& output, const partition_configuration& pc)
+{
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+    auto end_point_gen_json = [&writer](const ::dsn::rpc_address& ep, partition_status ps) {
+        if (ep.is_invalid())
+            return;
+        writer.StartObject();
+        writer.String("addr"); writer.String( ep.to_string() );
+        writer.String("partition_status"); writer.String( get_partition_status_string(ps) );
+        writer.EndObject();
+    };
+
+    writer.StartObject();
+
+    writer.String("app_type"); writer.String(pc.app_type.c_str());
+
+    std::stringstream gpid;
+    gpid << pc.gpid.app_id << "." << pc.gpid.pidx;
+    writer.String("gpid"); writer.String( gpid.str().c_str() );
+
+    writer.String("ballot"); writer.Int64(pc.ballot);
+    writer.String("max_replica_count"); writer.Int(pc.max_replica_count);
+    writer.String("last_committed_decree"); writer.Int64(pc.last_committed_decree);
+
+    writer.String("entries");
+    writer.StartArray();
+    end_point_gen_json(pc.primary, PS_PRIMARY);
+    for (unsigned int i=0; i!=pc.secondaries.size(); ++i)
+        end_point_gen_json(pc.secondaries[i], PS_SECONDARY);
+    for (unsigned int i=0; i!=pc.last_drops.size(); ++i)
+        end_point_gen_json(pc.last_drops[i], PS_INACTIVE);
+    writer.EndArray();
+
+    writer.EndObject();
+
+    std::shared_ptr<char> outptr(new char[buffer.GetSize()], [](char* ptr){ delete []ptr; } );
+    memcpy(outptr.get(), buffer.GetString(), buffer.GetSize());
+    output.assign(outptr, 0, buffer.GetSize());
+}
+
 void unmarshall(binary_reader& reader, /*out*/ app_state& val)
 {
     unmarshall(reader, val.app_type);
@@ -61,6 +157,65 @@ void unmarshall(binary_reader& reader, /*out*/ app_state& val)
     unmarshall(reader, val.app_id);
     unmarshall(reader, val.partition_count);
     unmarshall(reader, val.partitions);
+}
+
+void unmarshall_json(const blob& buf, app_state& app)
+{
+    rapidjson::Document doc;
+    std::string input(buf.data(), buf.length());
+    if (input.empty() || doc.Parse(input.c_str()).HasParseError() )
+        return;
+
+    app.app_type = doc["app_type"].GetString();
+    app.app_id = doc["app_id"].GetInt();
+    app.app_name = doc["app_name"].GetString();
+    app.partition_count = doc["partition_count"].GetInt();
+
+    partition_configuration pc;
+    pc.app_type = app.app_type;
+    pc.ballot = 0;
+    pc.gpid.app_id = app.app_id;
+    pc.last_committed_decree = 0;
+    pc.max_replica_count = 3;
+
+    app.partitions.assign(app.partition_count, pc);
+    for (unsigned int i=0; i!=app.partition_count; ++i)
+        app.partitions[i].gpid.pidx = i;
+}
+
+void unmarshall_json(const blob& buf, partition_configuration& pc)
+{
+    rapidjson::Document doc;
+    std::string input(buf.data(), buf.length());
+
+    if ( input.empty() || doc.Parse(input.c_str()).HasParseError())
+        return;
+
+    pc.app_type = doc["app_type"].GetString();
+    sscanf(doc["gpid"].GetString(), "%d.%d", &pc.gpid.app_id, &pc.gpid.pidx);
+    pc.ballot = doc["ballot"].GetInt64();
+    pc.max_replica_count = doc["max_replica_count"].GetInt();
+    pc.last_committed_decree = doc["last_committed_decree"].GetInt();
+    pc.primary.set_invalid();
+
+    rapidjson::Value& entries = doc["entries"];
+    for (rapidjson::SizeType i=0; i<entries.Size(); ++i) {
+        rapidjson::Value& val = entries[i];
+        ::dsn::rpc_address ep;
+        ep.from_string_ipv4(val["addr"].GetString());
+        partition_status ps = get_partition_status(val["partition_status"].GetString());
+        switch (ps) {
+        case PS_PRIMARY:
+            pc.primary = ep;
+            break;
+        case PS_SECONDARY:
+            pc.secondaries.push_back(ep);
+            break;
+        default:
+            pc.last_drops.push_back(ep);
+            break;
+        }
+    }
 }
 
 server_state::server_state()
@@ -216,14 +371,13 @@ error_code server_state::initialize_apps()
 
     // create cluster_root/apps/app_name node
     std::string app_path = join_path(apps_path, app.app_name);
-    binary_writer writer;
-    marshall(writer, app);
-    
-    blob value = writer.get_buffer();
+    blob value;
+    marshall_json(value, app);
 
     _storage->create_node(app_path, LPC_META_STATE_SVC_CALLBACK,
         [&err, this, &app, &tracker, &app_path](error_code ec)
         {
+            err = ec;
             if (ec == ERR_OK)
             {
                 int32_t max_replica_count = (int)dsn_config_get_value_uint64("replication.app",
@@ -244,32 +398,18 @@ error_code server_state::initialize_apps()
 
                     app.partitions.push_back(ps);
 
-                    binary_writer writer;
-                    marshall(writer, ps);
-
-                    blob value = writer.get_buffer();
+                    blob value;
+                    marshall_json(value, ps);
 
                     _storage->create_node(partition_path, LPC_META_STATE_SVC_CALLBACK,
                         [&err, this, &app](error_code ec)
                         {
-                            if (ec == ERR_OK)
-                            {
-
-                            }
-                            else
-                            {
-                                err = ec;
-                            }
+                            err = ec;
                         },
                         value,
                         &tracker
                         );
                 }
-                
-            }
-            else
-            {
-                err = ec;
             }
         },
         value,
@@ -298,6 +438,7 @@ error_code server_state::sync_apps_from_remote_storage()
     _storage->get_children(app_root, LPC_META_STATE_SVC_CALLBACK,
         [&](error_code ec, const std::vector<std::string>& apps)
         {
+            err = ec;
             if (ec == ERR_OK)
             {
                 // get app info
@@ -309,12 +450,11 @@ error_code server_state::sync_apps_from_remote_storage()
                         LPC_META_STATE_SVC_CALLBACK,
                         [this, app_path, &err, &tracker](error_code ec, const blob& value)
                     {
+                        err = ec;
                         if (ec == ERR_OK)
                         {
-                            binary_reader reader(value);
                             app_state state;
-                            unmarshall(reader, state);
-
+                            unmarshall_json(value, state);
                             int app_id = state.app_id;
                             dassert(app_id != 0, "invalid app id");
                             {
@@ -336,11 +476,11 @@ error_code server_state::sync_apps_from_remote_storage()
                                     LPC_META_STATE_SVC_CALLBACK,
                                     [this, app_id, i, par_path, &err](error_code ec, const blob& value)
                                     {
+                                        err = ec;
                                         if (ec == ERR_OK)
                                         {
-                                            binary_reader reader(value);
                                             partition_configuration pc;
-                                            unmarshall(reader, pc);
+                                            unmarshall_json(value, pc);
                                             zauto_write_lock l(_lock);
                                             _apps[app_id - 1].partitions[i] = pc;
                                         }
@@ -348,7 +488,6 @@ error_code server_state::sync_apps_from_remote_storage()
                                         {
                                             derror("get partition info from meta state service failed, path = %s, err = %s",
                                                 par_path.c_str(), ec.to_string());
-                                            err = ec;
                                         }
                                     },
                                     &tracker
@@ -359,7 +498,6 @@ error_code server_state::sync_apps_from_remote_storage()
                         {
                             derror("get app info from meta state service failed, path = %s, err = %s",
                                 app_path.c_str(), ec.to_string());
-                            err = ec;
                         }
                     },
                         &tracker
@@ -370,7 +508,6 @@ error_code server_state::sync_apps_from_remote_storage()
             {
                 derror("get app list from meta state service failed, path = %s, err = %s",
                     app_root.c_str(), ec.to_string());
-                err = ec;
             }
         },
         &tracker
@@ -384,29 +521,33 @@ error_code server_state::sync_apps_from_remote_storage()
         if (_apps.size() == 0)
             return ERR_OBJECT_NOT_FOUND;
 
-        auto& app = _apps[0];
-        for (int i = 0; i < app.partition_count; i++)
+        for (app_state& app: _apps) 
         {
-            auto& ps = app.partitions[i];
-
-            if (ps.primary.is_invalid() == false)
+            for (int i = 0; i < app.partition_count; i++)
             {
-                _nodes[ps.primary].primaries.insert(ps.gpid);
-                _nodes[ps.primary].partitions.insert(ps.gpid);
+                auto& ps = app.partitions[i];
+                auto refresh_state = [this](rpc_address addr, bool is_primary_role, global_partition_id gpid) -> bool {
+                    auto result_pair = this->_nodes.insert( std::make_pair(addr, node_state()) );
+                    node_state& ns = result_pair.first->second;
+                    ns.address = addr;
+                    ns.partitions.insert(gpid);
+                    if ( is_primary_role )
+                        ns.primaries.insert(gpid);
+                    
+                    if (result_pair.second==false || ns.is_alive==false) {
+                        this->_node_live_count++;
+                        ns.is_alive = true;
+                    }
+                };
+                
+                if ( !ps.primary.is_invalid() )
+                    refresh_state(ps.primary, true, ps.gpid);
+                for (auto& ep: ps.secondaries)
+                {
+                    dassert(ep.is_invalid() == false, "");
+                    refresh_state(ep, false, ps.gpid);
+                }
             }
-
-            for (auto& ep : ps.secondaries)
-            {
-                dassert(ep.is_invalid() == false, "");
-                _nodes[ep].partitions.insert(ps.gpid);
-            }
-        }
-
-        for (auto& node : _nodes)
-        {
-            node.second.address = node.first;
-            node.second.is_alive = true;
-            _node_live_count++;
         }
 
         for (auto& app : _apps)
@@ -631,11 +772,9 @@ void server_state::update_configuration(
             maintain_drops(req->config.last_drops, req->node, false);
             break;
         }
-        
-        binary_writer writer;
-        marshall(writer, req->config);
 
-        blob new_config_blob = writer.get_buffer();
+        blob new_config_blob;
+        marshall_json(new_config_blob, req->config);
         _storage->set_data(
             partition_path,
             new_config_blob,

--- a/src/apps/replication/meta_server/server_state.cpp
+++ b/src/apps/replication/meta_server/server_state.cpp
@@ -526,7 +526,7 @@ error_code server_state::sync_apps_from_remote_storage()
             for (int i = 0; i < app.partition_count; i++)
             {
                 auto& ps = app.partitions[i];
-                auto refresh_state = [this](rpc_address addr, bool is_primary_role, global_partition_id gpid) -> bool {
+                auto refresh_state = [this](rpc_address addr, bool is_primary_role, global_partition_id gpid) {
                     auto result_pair = this->_nodes.insert( std::make_pair(addr, node_state()) );
                     node_state& ns = result_pair.first->second;
                     ns.address = addr;

--- a/src/apps/replication/zookeeper/lock_struct.cpp
+++ b/src/apps/replication/zookeeper/lock_struct.cpp
@@ -322,6 +322,7 @@ void lock_struct::after_get_lock_owner(lock_struct_ptr _this, int ec, std::share
         if (_this->_myself._node_value == _this->_owner._node_value)
             _this->remove_duplicated_locknode(_this->_lock_dir + "/" + _this->_owner._node_seq_name);
         else {
+            _this->_dist_lock_service->refresh_lock_cache(_this->_lock_id, _this->_owner._node_value, _this->_owner._sequence_id);
             ddebug("wait the lock(%s) owner(%s:%s) to remove, myself(%s:%s)",
                    _this->_lock_id.c_str(),
                    _this->_owner._node_seq_name.c_str(), _this->_owner._node_value.c_str(),
@@ -483,6 +484,8 @@ void lock_struct::after_get_lockdir_nodes(lock_struct_ptr _this, int ec, std::sh
                     _this->_lock_dir.c_str(), myself_seq);
             _this->_state = lock_state::locked;
             _this->_owner._node_value = _this->_myself._node_value;
+            _this->_dist_lock_service->refresh_lock_cache(_this->_lock_id, _this->_owner._node_value, _this->_owner._sequence_id);
+
             watch_myself = true;
             ddebug("got the lock(%s), myself(%s:%s)", _this->_lock_id.c_str(), _this->_myself._node_seq_name.c_str(), _this->_myself._node_value.c_str());
             __lock_task_bind_and_enqueue(_this->_lock_callback, 
@@ -749,13 +752,6 @@ void lock_struct::unlock(lock_struct_ptr _this, unlock_task_t unlock_callback)
     _this->_state = lock_state::unlocking;
     _this->_unlock_callback = unlock_callback;
     _this->remove_my_locknode( _this->_lock_dir+"/"+_this->_myself._node_seq_name, DONT_IGNORE_CALLBACK, REMOVE_FOR_UNLOCK);
-}
-
-/*static*/
-void lock_struct::query(lock_struct_ptr _this, lock_task_t query_callback)
-{
-    _this->check_hashed_access();
-    __lock_task_bind_and_enqueue(query_callback, ERR_OK, _this->_owner._node_value, _this->_owner._sequence_id);
 }
 
 /*static*/

--- a/src/apps/replication/zookeeper/lock_struct.h
+++ b/src/apps/replication/zookeeper/lock_struct.h
@@ -68,7 +68,6 @@ public:
     static void try_lock(lock_struct_ptr _this, lock_task_t lock_callback, lock_task_t expire_callback);
     static void cancel_pending_lock(lock_struct_ptr _this, lock_task_t cancel_callback);
     static void unlock(lock_struct_ptr _this, unlock_task_t unlock_callback);
-    static void query(lock_struct_ptr _this, lock_task_t query_callback);
     
     static void lock_expired(lock_struct_ptr _this);
     

--- a/src/tests/distributed_lock_zookeeper.cpp
+++ b/src/tests/distributed_lock_zookeeper.cpp
@@ -105,7 +105,7 @@ TEST(distributed_lock_service_zookeeper, simple_lock_unlock)
     }
     
     int64_t expect_reuslt = 0;
-    for (int i: q) expect_reuslt += i;
+    for (int64_t i: q) expect_reuslt += i;
     
     ss_start = true;
     while ( !ss_finish ) 

--- a/src/tests/distributed_lock_zookeeper.cpp
+++ b/src/tests/distributed_lock_zookeeper.cpp
@@ -34,9 +34,10 @@ public:
         const char* args[] = { "/dsn/tests/simple_adder_server" };
         dassert(_dlock_service->initialize(1, args) == ERR_OK, "");
         
+        distributed_lock_service::lock_options opt = {true, true};
         while (!ss_finish) {
             std::pair<task_ptr, task_ptr> task_pair = _dlock_service->lock(
-                "test_lock", name(), true, 
+                "test_lock", name(), 
                 DLOCK_CALLBACK, 
                 [this](error_code ec, const std::string& name, int version)
                 {
@@ -51,7 +52,8 @@ public:
                 [this](error_code, const std::string&, int)
                 {
                     dassert(false, "session expired");
-                }
+                }, 
+                opt
             );
             task_pair.first->wait();
             for (int i=0; i<1000; ++i)
@@ -123,38 +125,43 @@ TEST(distributed_lock_service_zookeeper, abnormal_api_call)
     std::string my_id = "test_myid";
     std::string my_id2 = "test_myid2";
     
+    distributed_lock_service::lock_options opt = {false, true};
     std::pair<task_ptr, task_ptr> cb_pair = dlock_svc->lock(
-        lock_id, my_id, false, 
+        lock_id, my_id, 
         DLOCK_CALLBACK, 
         [](error_code ec, const std::string&, int){
             ASSERT_TRUE(ERR_OBJECT_NOT_FOUND==ec);
         },
         DLOCK_CALLBACK, 
-        nullptr
+        nullptr, 
+        opt
     );
     ASSERT_TRUE(cb_pair.first!=nullptr && cb_pair.second==nullptr);
     cb_pair.first->wait();
     
+    opt.create_if_not_exist = true;
     cb_pair = dlock_svc->lock(
-        lock_id, my_id, true, 
+        lock_id, my_id, 
         DLOCK_CALLBACK, [](error_code ec, const std::string&, int)
         {
             ASSERT_TRUE(ec == ERR_OK);
         }, 
         DLOCK_CALLBACK, 
-        nullptr
+        nullptr,
+        opt
     );
     ASSERT_TRUE(cb_pair.first!=nullptr && cb_pair.second!=nullptr);
     
     /* recursive lock */
-    std::pair<task_ptr, task_ptr> cb_pair2 = dlock_svc->lock(lock_id, my_id, true, 
+    std::pair<task_ptr, task_ptr> cb_pair2 = dlock_svc->lock(lock_id, my_id, 
         DLOCK_CALLBACK, 
         [](error_code ec, const std::string&, int)
         {
             ASSERT_TRUE(ec == ERR_RECURSIVE_LOCK);
         }, 
         DLOCK_CALLBACK, 
-        nullptr
+        nullptr, 
+        opt
     );
     ASSERT_TRUE(cb_pair2.first!=nullptr && cb_pair2.second!=nullptr);
     cb_pair2.first->wait();
@@ -183,13 +190,14 @@ TEST(distributed_lock_service_zookeeper, abnormal_api_call)
     );
     tsk->wait();
     
-    cb_pair2 = dlock_svc->lock(lock_id, my_id2, true, 
+    cb_pair2 = dlock_svc->lock(lock_id, my_id2, 
         DLOCK_CALLBACK, [my_id2](error_code ec, const std::string& name, int) { 
             ASSERT_TRUE(ec==ERR_OK);
             ASSERT_TRUE(name == my_id2);
         }, 
         DLOCK_CALLBACK, 
-        nullptr
+        nullptr, 
+        opt
     );
     
     bool result = cb_pair2.first->wait(2000);

--- a/src/tests/failure_detector.cpp
+++ b/src/tests/failure_detector.cpp
@@ -147,6 +147,7 @@ public:
     error_code start(int, char **) override
     {
         _master_fd = new master_fd_test();
+        _master_fd->active_failure_detector();
         _master_fd->start(1, 1, 4, 5);
         ++started_apps;
 


### PR DESCRIPTION
1. remove query_lock in meta_server_failure_detector, but read the cached data from dist lock
2. fix on meta_server_failure_detector, currently can response to ping when not leader
3. change data stored on meta_state_service from binary data to json
4. add api "query_cache" in dist_lock
