### PR TITLE
various fix in random number generation, task_queue and deploy script

### DIFF
--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -354,10 +354,6 @@ namespace dsn {
 
         extern char* trim_string(char* s);
 
-        extern uint64_t get_random64();
-
-        extern uint64_t get_random64_pseudo();
-
         extern uint64_t get_current_physical_time_ns();
 
         inline uint64_t get_current_rdtsc()

--- a/include/dsn/internal/env_provider.h
+++ b/include/dsn/internal/env_provider.h
@@ -37,6 +37,7 @@
 
 # include <dsn/ports.h>
 # include <dsn/cpp/utils.h>
+#include <random>
 
 namespace dsn {
 
@@ -50,12 +51,15 @@ public:
 
     typedef env_provider* (*factory)(env_provider*);
 
-public:
     env_provider(env_provider* inner_provider);
 
     virtual uint64_t now_ns() const { return utils::get_current_physical_time_ns(); }
 
     virtual uint64_t random64(uint64_t min, uint64_t max);
+
+protected:
+    static __thread int _tls_magic;
+    static __thread std::ranlux48_base* _rng;
 };
 
 } // end namespace

--- a/include/dsn/internal/task_queue.h
+++ b/include/dsn/internal/task_queue.h
@@ -61,10 +61,9 @@ public:
     virtual void     enqueue(task* task) = 0;
     virtual task*    dequeue() = 0;
     
-    int               approx_count() const { return _appro_count; }
-    int               decrease_count() { return --_appro_count; }
-    void              increase_count() { ++_appro_count; }
-    void              reset_count() { _appro_count = 0; }
+    int               approx_count() const { return _queue_length.load(std::memory_order_relaxed); }
+    void              decrease_count() { _queue_length.fetch_sub(1, std::memory_order_relaxed); }
+    void              increase_count() { _queue_length.fetch_add(1, std::memory_order_relaxed); }
     const std::string & get_name() { return _name; }    
     task_worker_pool* pool() const { return _pool; }
     bool              is_shared() const { return _worker_count > 1; }
@@ -88,7 +87,7 @@ private:
     int                    _index;
     admission_controller*  _controller;
     int                    _worker_count;
-    int                    _appro_count;
+    std::atomic_int        _queue_length;
     bool                   _enable_virtual_queue_throttling;
     volatile int           _virtual_queue_length;
     exp_delay              _delayer;

--- a/include/dsn/internal/task_spec.h
+++ b/include/dsn/internal/task_spec.h
@@ -259,8 +259,8 @@ struct threadpool_spec
     std::string             admission_controller_arguments;
 
     threadpool_spec(const dsn_threadpool_code_t& code) : pool_code(code), name(dsn_threadpool_code_to_string(code)) {}
-    threadpool_spec(const threadpool_spec& source);
-    threadpool_spec& operator=(const threadpool_spec& source);
+    threadpool_spec(const threadpool_spec& source) = default;
+    threadpool_spec& operator=(const threadpool_spec& source) = default;
 
     static bool init(/*out*/ std::vector<threadpool_spec>& specs);
 };

--- a/src/apps/replication/client_lib/replication_app_client_base.cpp
+++ b/src/apps/replication/client_lib/replication_app_client_base.cpp
@@ -400,7 +400,7 @@ Retry:
     // clear partition configuration as it could be wrong
     {
         zauto_write_lock l(_config_lock);
-        dwarn("met error[%d:%s], erase partition config cache, %d", err.get(), err.to_string(), rc->partition_index);
+        dinfo("met error[%d:%s], erase partition config cache, %d", err.get(), err.to_string(), rc->partition_index);
         _config_cache.erase(rc->partition_index);
     }
 

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -472,7 +472,10 @@ namespace dsn {
         auto& hdr = *request->header;
 
         hdr.client.port = primary_address().port();
-        hdr.rpc_id = utils::get_random64();        
+        hdr.rpc_id = dsn_random64(
+            std::numeric_limits<decltype(hdr.rpc_id)>::min(),
+            std::numeric_limits<decltype(hdr.rpc_id)>::max()
+            );
         request->seal(_message_crc_required);
         
         switch (request->server_address.type())

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -833,7 +833,6 @@ DSN_API uint64_t dsn_now_ns()
 
 DSN_API uint64_t dsn_random64(uint64_t min, uint64_t max) // [min, max]
 {
-    //return ::dsn::task::get_current_env()->random64(min, max);
     return ::dsn::service_engine::instance().env()->random64(min, max);
 }
 

--- a/src/core/core/task_queue.cpp
+++ b/src/core/core/task_queue.cpp
@@ -53,7 +53,7 @@ task_queue::task_queue(task_worker_pool* pool, int index, task_queue* inner_prov
     _name.append(num);
     _owner_worker = nullptr;
     _worker_count = _pool->spec().partitioned ? 1 : _pool->spec().worker_count;
-    _appro_count = 0;
+    _queue_length = 0;
     _virtual_queue_length = 0;
     _enable_virtual_queue_throttling = pool->spec().enable_virtual_queue_throttling;
     if (pool->spec().throttling_delay_vector_milliseconds.size() > 0)

--- a/src/core/core/task_spec.cpp
+++ b/src/core/core/task_spec.cpp
@@ -177,34 +177,6 @@ bool task_spec::init()
 }
 
 
-threadpool_spec::threadpool_spec(const threadpool_spec& source)
-    : pool_code(source.pool_code)
-{
-    *this = source;
-}
-
-threadpool_spec& threadpool_spec::operator=(const threadpool_spec& source)
-{
-    name = source.name;
-    pool_code = source.pool_code;
-    worker_count = source.worker_count;
-    worker_priority = source.worker_priority;
-    worker_share_core = source.worker_share_core;
-    worker_affinity_mask = source.worker_affinity_mask;
-    queue_length_throttling_threshold = source.queue_length_throttling_threshold;
-    partitioned = source.partitioned;
-
-    queue_factory_name = source.queue_factory_name;
-    worker_factory_name = source.worker_factory_name;
-    queue_aspects = source.queue_aspects;
-    worker_aspects = source.worker_aspects;
-
-    admission_controller_factory_name = source.admission_controller_factory_name;
-    admission_controller_arguments = source.admission_controller_arguments;
-
-    return *this;
-}
-
 bool threadpool_spec::init(/*out*/ std::vector<threadpool_spec>& specs)
 {
     /*

--- a/src/core/core/task_worker.cpp
+++ b/src/core/core/task_worker.cpp
@@ -332,11 +332,7 @@ void task_worker::loop()
             task* task = q->dequeue(), *next;
             while (task != nullptr)
             {
-                if (q->decrease_count() < 0)
-                {
-                    // fix count approximation
-                    q->reset_count();
-                }
+                q->decrease_count();
                 next = task->next;
                 task->next = nullptr;
                 task->exec_internal();

--- a/src/core/tools/common/asio_net_provider.cpp
+++ b/src/core/tools/common/asio_net_provider.cpp
@@ -216,7 +216,9 @@ namespace dsn {
                 do
                 {
                     //FIXME: we actually do not need to set a random port for clinet if the rpc_engine is refactored
-                    _address.assign_ipv4(get_local_ipv4(), std::numeric_limits<uint16_t>::max() - utils::get_random64() % 5000);
+                    _address.assign_ipv4(get_local_ipv4(), std::numeric_limits<uint16_t>::max() - 
+                        dsn_random64(std::numeric_limits<uint64_t>::min(),
+                                     std::numeric_limits<uint64_t>::max()) % 5000);
                     ::boost::asio::ip::udp::endpoint ep(boost::asio::ip::address_v4::any(), _address.port());
                     try
                     {

--- a/src/core/tools/simulator/env.sim.h
+++ b/src/core/tools/simulator/env.sim.h
@@ -45,8 +45,8 @@ public:
     sim_env_provider(env_provider* inner_provider);
 
     // service local time (can be logical or physical)
-    virtual uint64_t now_ns() const;
-    virtual uint64_t random64(uint64_t min, uint64_t max);
+    virtual uint64_t now_ns() const override;
+    virtual uint64_t random64(uint64_t min, uint64_t max) override;
 
     static int seed() { return _seed; }
 

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -182,42 +182,6 @@ namespace dsn {
             return r;
         }
 
-        class random64_generator : public singleton<random64_generator>
-        {
-        public:
-            random64_generator()
-                : _rng(std::random_device()())
-            {
-            }
-
-            uint64_t next()
-            {
-                return _dist(_rng);
-            }
-
-        private:
-            std::default_random_engine _rng;
-            std::uniform_int_distribution<uint64_t> _dist;
-        };
-
-
-        uint64_t get_random64()
-        {
-            return random64_generator::instance().next();
-        }
-
-        uint64_t get_random64_pseudo()
-        {
-            uint64_t v = ((uint64_t)std::rand());
-            v *= ((uint64_t)std::rand());
-            v *= ((uint64_t)std::rand());
-            v *= ((uint64_t)std::rand());
-            v *= ((uint64_t)std::rand());
-            v ^= ((uint64_t)std::rand());
-            return v;
-        }
-
-
         uint64_t get_current_physical_time_ns()
         {
             auto now = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
There are several notes about the implementation:
1. on vc2015 x64 release, the new random generator is actually faster than std::rand.
2. We need a thread-local random generator, but put it in tls_dsn seems not appropriate. So currently it is stored in env_provider.
3. Semantic change of run.cmd quickcleanup: it no longer delete the schtask.
4. previous utils::random64_generator is used in both core and application, but it is not thread safe at all, so I deleted it.
