### PR TITLE
reimplemented log replaying for performance

### DIFF
--- a/src/apps/replication/lib/mutation_log.h
+++ b/src/apps/replication/lib/mutation_log.h
@@ -364,8 +364,8 @@ private:
 //
 class log_file : public ref_counter
 {
-public:    
-    ~log_file() { close(); }
+public:
+    ~log_file();
 
     //
     // file operations
@@ -406,7 +406,7 @@ public:
     //  - ERR_INCOMPLETE_DATA
     //  - ERR_INVALID_DATA
     //  - other io errors caused by file read operator
-    error_code read_next_log_block(int64_t local_offset, /*out*/::dsn::blob& bb);
+    error_code read_next_log_block(/*out*/::dsn::blob& bb);
 
     //
     // write routines
@@ -438,8 +438,8 @@ public:
     //
     // others
     //
-
-    uint32_t& crc32() { return _crc32;  }
+    // reset file_streamer to point to the start of this log file.
+    void reset_stream();
     // end offset in the global space: end_offset = start_offset + file_size
     int64_t end_offset() const { return _end_offset; }
     // start offset in the global space
@@ -470,6 +470,8 @@ private:
     uint32_t         _crc32;
     int64_t          _start_offset; // start offset in the global space
     int64_t          _end_offset; // end offset in the global space: end_offset = start_offset + file_size
+    class file_streamer;
+    std::unique_ptr  <file_streamer> _stream;
     dsn_handle_t     _handle; // file handle
     bool             _is_read; // if opened for read or write
     std::string      _path; // file path

--- a/src/core/core/env_provider.cpp
+++ b/src/core/core/env_provider.cpp
@@ -49,6 +49,7 @@ env_provider::env_provider(env_provider* inner_provider)
     
 uint64_t env_provider::random64(uint64_t min, uint64_t max)
 {
+    dassert(min <= max, "invalid random range");
     if (_tls_magic != 0xdeadbeef)
     {
         _rng = new std::remove_pointer<decltype(_rng)>::type(std::random_device{}());

--- a/src/core/tests/env.cpp
+++ b/src/core/tests/env.cpp
@@ -43,7 +43,7 @@ TEST(core, env)
 {
     uint64_t xs[] = {
         0,
-        (uint64_t)-1LL,
+        std::numeric_limits<uint64_t>::max() - 1,
         0xdeadbeef
         };
 

--- a/src/tests/mutation_log.cpp
+++ b/src/tests/mutation_log.cpp
@@ -248,11 +248,11 @@ TEST(replication, log_file)
     ASSERT_EQ(lf->start_offset() + sz, lf->end_offset());
 
     // read data
-    lf->crc32() = 0;
+    lf->reset_stream();
     for (int i = 0; i < 100; i++)
     {
         blob bb;
-        auto err = lf->read_next_log_block(offset - lf->start_offset(), bb);
+        auto err = lf->read_next_log_block(bb);
         ASSERT_EQ(ERR_OK, err);
 
         binary_reader reader(bb);
@@ -274,7 +274,7 @@ TEST(replication, log_file)
     ASSERT_TRUE(offset == lf->end_offset());
 
     blob bb;
-    err = lf->read_next_log_block(offset - lf->start_offset(), bb);
+    err = lf->read_next_log_block(bb);
     ASSERT_TRUE(err == ERR_HANDLE_EOF);
 
     lf = nullptr;


### PR DESCRIPTION
Added relevant tests in dsn.tests. The test mimics real mutation replay latency and private-log block size. New replay implementation outperforms the old one for about 2.5X.

Also fixed #141 
