### PR TITLE
RPC&AIO perf test & fix in simple_kv perf client

### DIFF
--- a/src/apps/replication/exe/simple_kv.client.perf.h
+++ b/src/apps/replication/exe/simple_kv.client.perf.h
@@ -119,7 +119,7 @@ namespace dsn {
 
                     kv_pair req;
                     req.key = ss.str();
-                    req.value = "abcdefghijklmnopqrstuvwxyz1234567890";
+                    req.value = std::string(payload_bytes, 'x');
 
                     begin_write(req, ctx, _timeout_ms);
                 }
@@ -141,7 +141,7 @@ namespace dsn {
 
                     kv_pair req;
                     req.key = ss.str();
-                    req.value = "abcdefghijklmnopqrstuvwxyz1234567890";
+                    req.value = std::string(payload_bytes, 'x');
 
                     begin_append(req, ctx, _timeout_ms);
                 }

--- a/src/core/perf.tests/aio.cpp
+++ b/src/core/perf.tests/aio.cpp
@@ -1,3 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ * 
+ * -=- Robust Distributed System Nucleus (rDSN) -=- 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Description:
+ *     Disk IO performance test
+ *
+ * Revision history:
+ *     2016-01-05, Tianyi Wang, first version
+ */
 #include <dsn/cpp/address.h>
 #include <dsn/internal/aio_provider.h>
 #include <gtest/gtest.h>
@@ -14,7 +47,7 @@ void aio_testcase(uint64_t block_size, size_t concurrency, bool is_write, bool r
     std::unique_ptr<char[]> buffer(new char[block_size]);
     std::atomic_int remain_concurrency;
     remain_concurrency = concurrency;
-    if (utils::filesystem::file_exists("temp"))
+    if (is_write && utils::filesystem::file_exists("temp"))
     {
         utils::filesystem::remove_path("temp");
         dassert(!utils::filesystem::file_exists("temp"), "");
@@ -72,7 +105,7 @@ TEST(core, aio_perf_test)
     auto block_size_list = { 64, 512, 4096, 512 * 1024 };
     auto concurrency_list = { 1, 4, 16 };
     for (auto is_write : { true, false }) {
-        for (auto random_offset : { false, true }) {
+        for (auto random_offset : {true, false }) {
             for (auto block_size : block_size_list)
             {
                 for (auto concurrency : concurrency_list)

--- a/src/core/perf.tests/rpc.cpp
+++ b/src/core/perf.tests/rpc.cpp
@@ -1,0 +1,57 @@
+#include <dsn/cpp/address.h>
+#include <dsn/internal/aio_provider.h>
+#include <gtest/gtest.h>
+#include <dsn/service_api_cpp.h>
+#include <dsn/internal/priority_queue.h>
+#include "../core/group_address.h"
+#include "test_utils.h"
+#include <boost/lexical_cast.hpp>
+
+TEST(core, rpc_perf_test)
+{
+    ::dsn::rpc_address localhost("localhost", 20101);
+
+    ::dsn::rpc_read_stream response;
+    std::mutex lock;
+    for (auto concurrency : {100, 1000, 10000})
+    {
+        std::atomic_int remain_concurrency;
+        remain_concurrency = concurrency;
+        auto total_query_count = 20000;
+        std::chrono::steady_clock clock;
+        auto tic = clock.now();
+        for (;total_query_count --;)
+        {
+            while(true)
+            {
+                if (remain_concurrency.fetch_sub(1, std::memory_order_acquire) <= 0)
+                {
+                    remain_concurrency.fetch_add(1, std::memory_order_relaxed);
+                }
+                else
+                {
+                    break;
+                }
+            }
+            ::dsn::rpc::call_typed<int, std::string>(
+                localhost,
+                RPC_TEST_HASH,
+                0,
+                nullptr,
+                [&remain_concurrency](error_code ec, const std::string&, void*)
+                {
+                    ec.end_tracking();
+                    remain_concurrency.fetch_add(1, std::memory_order_relaxed);
+                },
+                nullptr
+            );
+        }
+        while(remain_concurrency != concurrency)
+        {
+            ;
+        }
+        auto toc = clock.now();
+        std::cout << "rpc perf test: concurrency = " << concurrency
+            << "time = " << std::chrono::duration_cast<std::chrono::microseconds>(toc - tic).count() << std::endl;
+    }
+}

--- a/src/core/perf.tests/rpc.cpp
+++ b/src/core/perf.tests/rpc.cpp
@@ -1,3 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ * 
+ * -=- Robust Distributed System Nucleus (rDSN) -=- 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Description:
+ *     Rpc performance test
+ *
+ * Revision history:
+ *     2016-01-05, Tianyi Wang, first version
+ */
 #include <dsn/cpp/address.h>
 #include <dsn/internal/aio_provider.h>
 #include <gtest/gtest.h>
@@ -51,7 +84,8 @@ TEST(core, rpc_perf_test)
             ;
         }
         auto toc = clock.now();
+        auto time_us = std::chrono::duration_cast<std::chrono::microseconds>(toc - tic).count();
         std::cout << "rpc perf test: concurrency = " << concurrency
-            << "time = " << std::chrono::duration_cast<std::chrono::microseconds>(toc - tic).count() << std::endl;
+            << " throughput = " << total_query_count * 1000000 / time_us << "call/sec" << std::endl;
     }
 }


### PR DESCRIPTION
payload_bytes in simple_kv.client.perf is actually just ignored in current implementation. All the throughput measurement was wrong.
