### PR TITLE
fix some build error

### DIFF
--- a/include/dsn/ports.h
+++ b/include/dsn/ports.h
@@ -70,6 +70,7 @@ __pragma(warning(disable:4127))
 # include <list>
 # include <algorithm>
 
+# define __STDC_FORMAT_MACROS
 // common c headers
 # include <cassert>
 # include <cstring>
@@ -117,3 +118,4 @@ __pragma(warning(disable:4127))
 # define snprintf_p std::snprintf
 # endif
 # endif
+

--- a/src/dev/cpp/perf_test_helper.cpp
+++ b/src/dev/cpp/perf_test_helper.cpp
@@ -282,7 +282,7 @@ namespace dsn {
             cs.timeout_rounds = 0;
             cs.error_rounds = 0;
             cs.max_latency_ns = 0;
-            cs.min_latency_ns = UINT64_MAX;
+            cs.min_latency_ns = std::numeric_limits<uint64_t>::max();
 
             // setup for the case
             _current_case = &cs;


### PR DESCRIPTION
1. change UINT64_MAX to std::numeric_limits<uint64_t>::max()
   based on 
   http://stackoverflow.com/questions/16298650/macro-representing-maximum-value-for-uint64-t
2. add __STDC_FORMAT_MACROS to print PRIu64
   based on 
   http://stackoverflow.com/questions/8132399/how-to-printf-uint64-t
