### PR TITLE
fix that: while running dsn.cg.bat without point out its full path bu…

### DIFF
--- a/bin/dsn.cg.bat
+++ b/bin/dsn.cg.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
-FOR /f %%i IN ("%0") DO SET CODEGEN_ROOT=%%~dpi
+SET CODEGEN_ROOT=%~dp0
 CALL php -f %CODEGEN_ROOT%\dsn.generate_code.php %1 %2 %3 %4 %5 %6 %7 %8 %9 
 :EOF


### PR DESCRIPTION
…t via the enviroment variable of %PATH%, the variable %CODEGEN_ROOT% will be set to a wrong value.
