### PR TITLE
serveral small performance fixes. copy pdb in publish.cmd

### DIFF
--- a/scripts/windows/publish.cmd
+++ b/scripts/windows/publish.cmd
@@ -34,7 +34,7 @@ IF "%bt_valid%" EQU "0" (
     CALL %bin_dir%\echoc.exe 4 invalid build_type '%build_type%'
     GOTO error
 )
-
+COPY /Y %build_dir%\bin\%build_type%\dsn.core.pdb .\skv\%app%
 CALL %bin_dir%\publish.%app_name%.cmd %cmd% %build_dir% %build_type% %monitor_url%
 GOTO exit
 

--- a/src/core/core/task.cpp
+++ b/src/core/core/task.cpp
@@ -129,12 +129,11 @@ __thread uint16_t tls_dsn_lower32_task_id_mask = 0;
 }
 
 task::task(dsn_task_code_t code, void* context, dsn_task_cancelled_handler_t on_cancel, int hash, service_node* node)
-    : _state(TASK_STATE_READY)
+    : _state(TASK_STATE_READY), _wait_event(nullptr)
 {
     _spec = task_spec::get(code);
     _context = context;
     _on_cancel = on_cancel;
-    _wait_event.store(nullptr);
     _hash = hash;
     _delay_milliseconds = 0;
     _wait_for_cancel = false;
@@ -187,7 +186,6 @@ void task::exec_internal()
         _spec->on_task_begin.execute(this);
 
         exec();
-        
         if (_state.compare_exchange_strong(RUNNING_STATE, TASK_STATE_FINISHED))
         {
             _spec->on_task_end.execute(this);

--- a/src/core/tools/hpc/hpc_logger.cpp
+++ b/src/core/tools/hpc/hpc_logger.cpp
@@ -117,13 +117,13 @@ namespace dsn
         //daemon thread
         void hpc_logger::log_thread()
         {
-            std::list<buffer_info> saved_list;
+            std::vector<buffer_info> saved_list;
 
             while (!_stop_thread)
             {
                 _write_list_lock.lock();
                 _write_list_cond.wait(_write_list_lock, [=]{ return  _stop_thread || _write_list.size() > 0; });
-                saved_list = _write_list;
+                saved_list = std::move(_write_list);
                 _write_list.clear();
                 _write_list_lock.unlock();
                 
@@ -350,19 +350,13 @@ namespace dsn
 
         void hpc_logger::buffer_push(char* buffer, int size)
         {
-            buffer_info new_buffer_info;
-            new_buffer_info.buffer = buffer;
-            new_buffer_info.buffer_size = size;
-            _write_list.push_back(new_buffer_info);
+            _write_list.emplace_back(buffer, size); 
         }
 
-        void hpc_logger::write_buffer_list(std::list<buffer_info>& llist)
+        void hpc_logger::write_buffer_list(std::vector<buffer_info>& llist)
         {
-            while (!llist.empty())
+            for (auto& new_buffer_info : llist)
             {
-                buffer_info new_buffer_info = llist.front();
-                llist.pop_front();
-
                 if (_current_log_file_bytes + new_buffer_info.buffer_size >= MAX_FILE_SIZE)
                 {
                     _current_log->close();
@@ -378,6 +372,7 @@ namespace dsn
 
                 free(new_buffer_info.buffer);
             }
+            llist.clear();
         }
     }
 }

--- a/src/core/tools/hpc/hpc_logger.h
+++ b/src/core/tools/hpc/hpc_logger.h
@@ -43,11 +43,12 @@
 
 namespace dsn {
     namespace tools {
-        typedef struct __buffer_info__
+        struct buffer_info
         {
             char*    buffer;
             int      buffer_size;
-        } buffer_info;
+            buffer_info(char* buffer, int buffer_size) : buffer(buffer), buffer_size(buffer_size) {}
+        };
 
         class hpc_logger : public logging_provider
         {
@@ -72,7 +73,7 @@ namespace dsn {
             void flush_all_buffers_at_exit();
             void buffer_push(char* buffer, int size);
             //print logs in log list
-            void write_buffer_list(std::list<buffer_info>& llist);
+            void write_buffer_list(std::vector<buffer_info>& llist);
             void create_log_file();
 
         private:            
@@ -83,7 +84,7 @@ namespace dsn {
             // global buffer list
             std::condition_variable_any   _write_list_cond;
             ::dsn::utils::ex_lock_nr_spin _write_list_lock;            
-            std::list<buffer_info>        _write_list;
+            std::vector<buffer_info>        _write_list;
 
             // log file and line count
             int _start_index;


### PR DESCRIPTION
The default memory order for `std::atomic` is `memory_order_seq_cst`, which generates `mfence` on x86. It is super costly. We might be unaware of this issue on other parts of code and I'm searching for them.
