### PR TITLE
added moodycamel/concurrentqueue as the default task queue provider f…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ dsn_add_pseudo_projects()
 add_subdirectory(ext/gtest)
 add_subdirectory(ext/zookeeper)
 add_subdirectory(ext/rapidjson)
+add_subdirectory(ext/concurrentqueue)
 #
 # !!! gflags is currently not used, and when it is enabled, it causes failure on windows compilation
 # add_subdirectory(ext/gflags)

--- a/include/dsn/internal/task.h
+++ b/include/dsn/internal/task.h
@@ -122,7 +122,7 @@ public:
     void                    set_tracker(task_tracker* tracker) { _context_tracker.set_tracker(tracker, this); }
 
     uint64_t                id() const { return _task_id; }
-    task_state              state() const { return _state.load(); }
+    task_state              state() const { return _state.load(std::memory_order_acquire); }
     dsn_task_code_t         code() const { return _spec->code; }
     task_spec&              spec() const { return *_spec; }
     int                     hash() const { return _hash; }

--- a/src/core/perf.tests/config-test.ini
+++ b/src/core/perf.tests/config-test.ini
@@ -9,10 +9,10 @@ count = 1
 type = test
 arguments = localhost 20101
 run = true
-ports = 
+ports =
 count = 1
 delay_seconds = 1
-pools = THREAD_POOL_DEFAULT, THREAD_POOL_TEST_SERVER
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_TEST_SERVER, THREAD_POOL_TEST_TASK_QUEUE_1, THREAD_POOL_TEST_TASK_QUEUE_2
 
 [apps.server]
 type = test
@@ -35,7 +35,7 @@ pools = THREAD_POOL_DEFAULT, THREAD_POOL_TEST_SERVER
 ;tool = nativerun
 tool = fastrun
 
-toollets = tracer, profiler, fault_injector
+;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 cli_local = false
 cli_remote = false
@@ -43,8 +43,8 @@ cli_remote = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 
-;io_mode = IOE_PER_NODE
-io_mode = IOE_PER_QUEUE
+io_mode = IOE_PER_NODE
+;io_mode = IOE_PER_QUEUE
 io_worker_count = 1
 
 [tools.simulator]
@@ -74,6 +74,7 @@ is_profile = false
 
 ; specification for each thread pool
 [threadpool..default]
+queue_factory_name = dsn::tools::hpc_concurrent_task_queue
 worker_count = 2
 
 [threadpool.THREAD_POOL_DEFAULT]
@@ -84,7 +85,14 @@ worker_priority = THREAD_xPRIORITY_NORMAL
 [threadpool.THREAD_POOL_TEST_SERVER]
 partitioned = false
 
+[threadpool.THREAD_POOL_TEST_TASK_QUEUE_1]
+worker_count = 1
+partitioned = false
+
+[threadpool.THREAD_POOL_TEST_TASK_QUEUE_2]
+worker_count = 1
+partitioned = false
+
 [core.test]
 count = 1
 run = true
-

--- a/src/core/perf.tests/task_queue.cpp
+++ b/src/core/perf.tests/task_queue.cpp
@@ -1,0 +1,222 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ * 
+ * -=- Robust Distributed System Nucleus (rDSN) -=- 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Description:
+ *     Rpc performance test
+ *
+ * Revision history:
+ *     2016-01-05, Tianyi Wang, first version
+ */
+
+#include <dsn/cpp/address.h>
+#include <dsn/internal/aio_provider.h>
+#include <gtest/gtest.h>
+#include <dsn/service_api_cpp.h>
+#include <dsn/internal/priority_queue.h>
+#include "../core/group_address.h"
+#include <boost/lexical_cast.hpp>
+#include "test_utils.h"
+#include <mutex>
+#include <condition_variable>
+
+//worker = 1
+DEFINE_THREAD_POOL_CODE(THREAD_POOL_TEST_TASK_QUEUE_1);
+//worker = 1
+DEFINE_THREAD_POOL_CODE(THREAD_POOL_TEST_TASK_QUEUE_2);
+DEFINE_TASK_CODE(LPC_TEST_TASK_QUEUE_1, TASK_PRIORITY_HIGH, THREAD_POOL_TEST_TASK_QUEUE_1)
+DEFINE_TASK_CODE(LPC_TEST_TASK_QUEUE_2, TASK_PRIORITY_HIGH, THREAD_POOL_TEST_TASK_QUEUE_2)
+
+struct auto_timer {
+    std::string prefix;
+    uint64_t delivery;
+    std::chrono::steady_clock clock;
+    decltype(clock.now()) start_time;
+    std::vector<task_ptr> waited_task;
+    auto_timer(const std::string& prefix, uint64_t delivery) : prefix(prefix), delivery(delivery)
+    {
+        start_time = clock.now();
+    }
+    void wait_task(task_ptr ptask)
+    {
+        waited_task.push_back(ptask);
+    }
+    ~auto_timer()
+    {
+        for (auto task : waited_task)
+        {
+            task->wait();
+        }
+        auto end_time = clock.now();
+        std::cout << prefix << "throughput = " << delivery * 1000 * 1000 / std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count() << std::endl;
+    }
+};
+
+void empty_cb(void*)
+{
+    
+}
+struct self_iterate_context
+{
+    std::mutex mut;
+    std::condition_variable cv;
+    bool done = false;
+    std::vector<task_c*> tsks;
+    std::vector<task_c*>::iterator it;
+};
+void iterate_over_preallocated_tasks(void* ctx)
+{
+    auto context = reinterpret_cast<self_iterate_context*>(ctx);
+    if (context->it != context->tsks.end())
+    {
+        auto it_save = context->it;
+        ++context->it;
+        (*it_save)->enqueue();
+    }
+    else
+    {
+        {
+            std::lock_guard<std::mutex> _(context->mut);
+            context->done = true;
+        }
+        context->cv.notify_one();
+    }
+}
+
+void external_flooding(const int enqueue_time)
+{
+    std::vector<task_c*> tsks;
+    for (int i = 0; i < enqueue_time; i++)
+    {
+        auto tsk = new task_c(LPC_TEST_TASK_QUEUE_1, empty_cb, nullptr, nullptr);
+        tsks.push_back(tsk);
+    }
+    {
+        auto_timer t("inter-thread flooding test:", enqueue_time);
+        for (auto tsk : tsks)
+        {
+            if (tsk == tsks.back())
+            {
+                tsk->add_ref();
+            }
+            tsk->enqueue();
+        }
+        tsks.back()->wait();
+        tsks.back()->release_ref();
+    }
+}
+
+void self_flooding(const int enqueue_time)
+{
+    std::vector<task_c*> tsks;
+    for (int i = 0; i < enqueue_time; i++)
+    {
+        auto tsk = new task_c(LPC_TEST_TASK_QUEUE_1, empty_cb, nullptr, nullptr);
+        tsks.push_back(tsk);
+    }
+    {
+        auto_timer t("self-flooding test:", enqueue_time);
+        tasking::enqueue(LPC_TEST_TASK_QUEUE_1, nullptr, [&]()
+        {
+            for (auto tsk : tsks)
+            {
+                if (tsk == tsks.back())
+                {
+                    tsk->add_ref();
+                }
+                tsk->enqueue();
+            }
+            t.start_time = t.clock.now();
+        });
+        tsks.back()->wait();
+        tsks.back()->release_ref();
+    }
+}
+void external_blocking(const int enqueue_time)
+{
+    std::vector<task_c*> tsks;
+    for (int i = 0; i < enqueue_time; i++)
+    {
+        auto tsk = new task_c(LPC_TEST_TASK_QUEUE_1, empty_cb, nullptr, nullptr);
+        tsks.push_back(tsk);
+    }
+    {
+        auto_timer t("inter-thread blocking test:", enqueue_time);
+        for (auto tsk : tsks)
+        {
+            tsk->add_ref();
+            tsk->enqueue();
+            tsk->wait();
+            tsk->release_ref();
+        }
+    }
+}
+void self_iterating(const int enqueue_time)
+{
+    self_iterate_context ctx;
+    for (int i = 0; i < enqueue_time; i++)
+    {
+        auto tsk = new task_c(LPC_TEST_TASK_QUEUE_1, iterate_over_preallocated_tasks, &ctx, nullptr);
+        ctx.tsks.push_back(tsk);
+    }
+    ctx.it = ctx.tsks.begin();
+    {
+        auto_timer t("self-iterating test:", enqueue_time);
+        iterate_over_preallocated_tasks(&ctx);
+        std::unique_lock<std::mutex> _lk(ctx.mut);
+        ctx.cv.wait(_lk, [&] {return ctx.done;});
+    }
+}
+void tic_tock_iterating(const int enqueue_time)
+{
+    self_iterate_context ctx;
+    for (int i = 0; i < enqueue_time; i++)
+    {
+        auto tsk = new task_c(
+            i % 2 == 0 ? LPC_TEST_TASK_QUEUE_1 : LPC_TEST_TASK_QUEUE_2,
+            iterate_over_preallocated_tasks,
+            &ctx,
+            nullptr
+            );
+        ctx.tsks.push_back(tsk);
+    }
+    ctx.it = ctx.tsks.begin();
+    {
+        auto_timer t("tick-tock test:", enqueue_time);
+        iterate_over_preallocated_tasks(&ctx);
+        std::unique_lock<std::mutex> _lk(ctx.mut);
+        ctx.cv.wait(_lk, [&] {return ctx.done;});
+    }
+}
+TEST(core, task_queue_perf_test)
+{
+    const int enqueue_time = 10000000;
+    external_flooding(enqueue_time);
+    self_flooding(enqueue_time);
+    external_blocking(enqueue_time / 10);
+    self_iterating(enqueue_time);
+    tic_tock_iterating(enqueue_time / 10);
+}

--- a/src/core/tools/hpc/CMakeLists.txt
+++ b/src/core/tools/hpc/CMakeLists.txt
@@ -9,7 +9,8 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_INC_PATH "")
+set(MY_PROJ_INC_PATH ""
+${CONQUEUE_INCLUDE_DIRS})
 
 set(MY_PROJ_LIBS "")
 
@@ -19,3 +20,4 @@ set(MY_PROJ_LIB_PATH "")
 set(MY_BINPLACES "")
 
 dsn_add_static_library()
+add_dependencies(${MY_PROJ_NAME} concurrentqueue)

--- a/src/core/tools/hpc/fastrun.cpp
+++ b/src/core/tools/hpc/fastrun.cpp
@@ -124,7 +124,7 @@ namespace dsn
 
                 if (tspec.queue_factory_name == "")
                     tspec.queue_factory_name = use_mixed_queue ? ("dsn::tools::io_looper_task_queue")
-                                                                : "dsn::tools::hpc_task_priority_queue";
+                                                                : "dsn::tools::hpc_concurrent_task_queue";
             }
 
         }

--- a/src/core/tools/hpc/providers.hpc.cpp
+++ b/src/core/tools/hpc/providers.hpc.cpp
@@ -51,6 +51,7 @@ namespace dsn {
             register_component_provider<hpc_logger>("dsn::tools::hpc_logger");
             register_component_provider<hpc_task_queue>("dsn::tools::hpc_task_queue");
             register_component_provider<hpc_task_priority_queue>("dsn::tools::hpc_task_priority_queue");            
+            register_component_provider<hpc_concurrent_task_queue>("dsn::tools::hpc_concurrent_task_queue");
             register_component_provider<hpc_env_provider>("dsn::tools::hpc_env_provider");
             
             register_component_provider<hpc_aio_provider>("dsn::tools::hpc_aio_provider");


### PR DESCRIPTION
…or fastrun. Fixed unnecessary seq_cst sync in task::task_state. added benchmark for task_queue. Set default sim_net delay to 0.
### about the queue

moodycamel/concurrentqueue is a fast MPMC queue, released under BSD licence. It is much faster than naive implementations, including boost and TBB implementations. Its implementation is complicated and I don't think there is a way to hand-craft a queue that is comparable to it.
### performance change

I tested the performance of hpc_priority_task_queue and the newly added hpc_concurrent_task_queue using core.task_queue_perf_test. Here's their performance:
#### hpc_concurrent_task_queue

```
inter-thread flooding test:throughput = 6672467
self-flooding test:throughput = 7226603
inter-thread blocking test:throughput = 1046366
self-iterating test:throughput = 4041782
tick-tock test:throughput = 2700396
```
#### hpc_priority_task_queue

```
inter-thread flooding test:throughput = 5152068
self-flooding test:throughput = 7956709
inter-thread blocking test:throughput = 100560
self-iterating test:throughput = 6062134
tick-tock test:throughput = 266755
```

We can see that hpc_concurrent_task_queue is much faster under contention or partially-idle 
workloads.  
### discussion about performance

The performance of our task_queues is not ideal. I did profiling on the benchmarks and the current most prominent overhead lies within the free procedure of tasks. Maybe memory pool of frequently used objects is needed.
### discussion about atomic variables

It seems that many of us aren't aware of the proper usage of std::atomic and memory_order. Here is some rule of thumb:
1. the default memory order of atomic variables is `std::memory_order_seq_cst`. It has high overhead (~100 cycles on x86) and is hardly necessary. Actually a well-behaved spinlock does not need seq_cst synchronization.
2. Acquire-release pairs is (and should be!) widely used to ensure safety.
3. Consume-release pairs might be a faster version of acquire-release if you are aware of data dependency around atomic operations.

I recommend this article for reference: http://preshing.com/20140709/the-purpose-of-memory_order_consume-in-cpp11/
### broken assumptions

default sim_net delay is set to 0 to avoid confusion
the default task_queue factory is hpc_concurrent_task_queue now
### misc

@imzhenyu you can update imzhenyu/concurrentqueue from upstream
