### PR TITLE
  fix crash bug in rpc_engine::call_ip when msg is re-sent while it is  in sending queue

### DIFF
--- a/include/dsn/service_api_c.h
+++ b/include/dsn/service_api_c.h
@@ -77,8 +77,10 @@
 
 # ifdef __cplusplus
 # define DEFAULT(value) = value
+# define NORETURN [[noreturn]]
 # else
 # define DEFAULT(value)
+# define NORETURN 
 # endif
 
 # ifdef __cplusplus
@@ -347,7 +349,7 @@ extern DSN_API bool      dsn_run_config(
 // Note the argc, argv folllows the C main convention that argv[0] is the executable name
 //
 extern DSN_API void dsn_run(int argc, char** argv, bool sleep_after_init DEFAULT(false));
-[[noreturn]] extern DSN_API void dsn_exit(int code);
+NORETURN extern DSN_API void dsn_exit(int code);
 extern DSN_API int  dsn_get_all_apps(dsn_app_info* info_buffer, int count); // return real app count
 extern DSN_API bool dsn_get_current_app_info(/*out*/ dsn_app_info* app_info);
 extern DSN_API const char* dsn_get_current_app_data_dir();

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -591,7 +591,10 @@ namespace dsn {
 
         while (!request->dl.is_alone())
         {
-            dwarn("msg request %s is in sending queue, try to pick out ...");
+            dwarn("msg request %s (%" PRIx64 ") is in sending queue, try to pick out ...",
+                request->header->rpc_name,
+                request->header->rpc_id
+                );
             auto s = request->io_session;
             if (s.get() != nullptr)
             {

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -941,7 +941,7 @@ err:
 }
 #endif
 
-[[noreturn]] DSN_API void dsn_exit(int code)
+NORETURN DSN_API void dsn_exit(int code)
 {
 # if defined(_WIN32)
     // TODO: do not use std::map above, coz when suspend the other threads, they may stop


### PR DESCRIPTION
  fix crash bug in rpc_engine::call_ip when msg is re-sent while it is  in sending queue
