### PR TITLE
add rpc retry logic for rpc requests not responsed for some time befo…

### DIFF
--- a/include/dsn/internal/task_spec.h
+++ b/include/dsn/internal/task_spec.h
@@ -189,6 +189,7 @@ public:
     network_header_format  rpc_call_header_format;
     rpc_channel            rpc_call_channel;
     int32_t                rpc_timeout_milliseconds;
+    int32_t                rpc_request_resend_timeout_milliseconds; // 0 for no auto-resend
     // ]
 
     task_rejection_handler rejection_handler;
@@ -238,6 +239,7 @@ CONFIG_BEGIN(task_spec)
     CONFIG_FLD_ID(network_header_format, rpc_call_header_format, NET_HDR_DSN, false, "what kind of header format for this kind of rpc calls")
     CONFIG_FLD_ID(rpc_channel, rpc_call_channel, RPC_CHANNEL_TCP, false, "what kind of network channel for this kind of rpc calls")
     CONFIG_FLD(int32_t, uint64, rpc_timeout_milliseconds, 5000, "what is the default timeout (ms) for this kind of rpc calls")    
+    CONFIG_FLD(int32_t, uint64, rpc_request_resend_timeout_milliseconds, 0, "for how long (ms) the request will be resent if no response is received yet, 0 for disable this feature")
 CONFIG_END
 
 struct threadpool_spec

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -183,7 +183,7 @@ namespace dsn {
             auto it = _requests[bucket_index].find(key);
             if (it != _requests[bucket_index].end())
             {
-                timeout_ts_ms = it->second.timeout_ms;
+                timeout_ts_ms = it->second.timeout_ts_ms;
                 call = it->second.resp_task;
                 if (timeout_ts_ms == 0)
                 {

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -88,7 +88,7 @@ namespace dsn {
     {
         for (int i = 0; i < MATCHER_BUCKET_NR; i++)
         {
-            dassert(_requests[i].size() == 0, "all rpc enries must be removed before the matcher ends");
+            dassert(_requests[i].size() == 0, "all rpc entries must be removed before the matcher ends");
         }
     }
 
@@ -174,15 +174,29 @@ namespace dsn {
     void rpc_client_matcher::on_rpc_timeout(uint64_t key)
     {
         rpc_response_task* call;
-        int bucket_index = key % MATCHER_BUCKET_NR;
+        int bucket_index = key % MATCHER_BUCKET_NR;        
+        uint64_t timeout_ts_ms;
+        bool resend = false;
 
         {
             utils::auto_lock< ::dsn::utils::ex_lock_nr_spin> l(_requests_lock[bucket_index]);
             auto it = _requests[bucket_index].find(key);
             if (it != _requests[bucket_index].end())
             {
+                timeout_ts_ms = it->second.timeout_ms;
                 call = it->second.resp_task;
-                _requests[bucket_index].erase(it);
+                if (timeout_ts_ms == 0)
+                {
+                    _requests[bucket_index].erase(it);
+                }
+
+                // resend is enabled
+                else
+                {
+                    // do it in next check so we can do expensive things
+                    // outside of the lock
+                    resend = true;
+                }
             }
             else
             {
@@ -190,10 +204,73 @@ namespace dsn {
             }
         }
 
-        dbg_dassert(call != nullptr, "rpc response task cannot be empty");
-        call->enqueue(ERR_TIMEOUT, nullptr);
+        dbg_dassert(call != nullptr,
+            "rpc response task is missing for rpc request %" PRIu64, key);
 
-        call->release_ref(); // added in on_call
+        // if timeout
+        if (!resend)
+        {
+            call->enqueue(ERR_TIMEOUT, nullptr);
+            call->release_ref(); // added in on_call
+            return;
+        }
+
+        // prepare resend context and check again
+        uint64_t now_ts_ms = dsn_now_ms();
+
+        // resend when timeout is not yet, and the call is not cancelled
+        // TODO: time overflow
+        resend = (now_ts_ms < timeout_ts_ms && call->state() == TASK_STATE_READY);
+
+        // TODO: memory pool for this task
+        task* new_timeout_task = resend ? new rpc_timeout_task(this, key, call->node()) : nullptr;
+
+        {
+            utils::auto_lock< ::dsn::utils::ex_lock_nr_spin> l(_requests_lock[bucket_index]);
+            auto it = _requests[bucket_index].find(key);
+            if (it != _requests[bucket_index].end())
+            {
+                // timeout                
+                if (!resend)
+                {
+                    _requests[bucket_index].erase(it);
+                }
+
+                // resend
+                else
+                {
+                    // reset timeout task
+                    it->second.timeout_task = new_timeout_task;
+                }
+            }
+
+            // response is received
+            else
+            {
+                resend = false;
+            }
+        }
+
+        if (resend)
+        {
+            auto req = call->get_request();
+            dinfo("resend reqeust message for rpc %" PRIx64 ", key = %" PRIu64,
+                req->header->rpc_id, key);
+
+            // resend without handling rpc_matcher and reset rquest id
+            _engine->call_ip(req->to_address, req, nullptr, false);
+
+            // use rest of the timeout to resend once only
+            new_timeout_task->set_delay(timeout_ts_ms - now_ts_ms);
+            new_timeout_task->enqueue();
+        }
+        else
+        {
+            if (new_timeout_task)
+            {
+                delete new_timeout_task;
+            }
+        }
     }
     
     void rpc_client_matcher::on_call(message_ex* request, rpc_response_task* call)
@@ -201,19 +278,29 @@ namespace dsn {
         task* timeout_task;
         message_header& hdr = *request->header;
         int bucket_index = hdr.id % MATCHER_BUCKET_NR;
+        auto sp = task_spec::get(request->local_rpc_code);
+        int timeout_ms = hdr.client.timeout_ms;
+        uint64_t timeout_ts_ms = 0;
+        
+        // reset timeout when resend is enabled
+        if (sp->rpc_request_resend_timeout_milliseconds > 0 && 
+            timeout_ms > sp->rpc_request_resend_timeout_milliseconds
+            )
+        {
+            timeout_ts_ms = dsn_now_ms() + timeout_ms; // non-zero for resend
+            timeout_ms = sp->rpc_request_resend_timeout_milliseconds;            
+        }
 
         dbg_dassert(call != nullptr, "rpc response task cannot be empty");
         timeout_task = (new rpc_timeout_task(this, hdr.id, call->node()));
 
         {
             utils::auto_lock< ::dsn::utils::ex_lock_nr_spin> l(_requests_lock[bucket_index]);
-            auto pr = _requests[bucket_index].insert(rpc_requests::value_type(hdr.id, match_entry()));
+            auto pr = _requests[bucket_index].emplace(hdr.id, match_entry { call, timeout_task, timeout_ts_ms });
             dassert (pr.second, "the message is already on the fly!!!");
-            pr.first->second.resp_task = call;
-            pr.first->second.timeout_task = timeout_task;
         }
 
-        timeout_task->set_delay(hdr.client.timeout_ms);
+        timeout_task->set_delay(timeout_ms);
         timeout_task->enqueue();
 
         call->add_ref(); // released in on_rpc_timeout or on_recv_reply

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -195,6 +195,10 @@ namespace dsn {
                 {
                     // do it in next check so we can do expensive things
                     // outside of the lock
+
+                    // call may be eliminated from this container and deleted after its execution
+                    // we therefore add_ref here
+                    call->add_ref();  // released after re-send
                     resend = true;
                 }
             }
@@ -271,6 +275,8 @@ namespace dsn {
                 delete new_timeout_task;
             }
         }
+
+        call->release_ref(); // added inside the first check of resend
     }
     
     void rpc_client_matcher::on_call(message_ex* request, rpc_response_task* call)

--- a/src/core/core/rpc_engine.h
+++ b/src/core/core/rpc_engine.h
@@ -91,6 +91,7 @@ private:
     {
         rpc_response_task*    resp_task;
         task*                 timeout_task;
+        uint64_t              timeout_ms; // for auto-resent msgs
     };
     typedef std::unordered_map<uint64_t, match_entry> rpc_requests;
     rpc_requests                  _requests[MATCHER_BUCKET_NR];

--- a/src/core/core/rpc_engine.h
+++ b/src/core/core/rpc_engine.h
@@ -91,7 +91,7 @@ private:
     {
         rpc_response_task*    resp_task;
         task*                 timeout_task;
-        uint64_t              timeout_ms; // for auto-resent msgs
+        uint64_t              timeout_ts_ms; // > 0 for auto-resent msgs
     };
     typedef std::unordered_map<uint64_t, match_entry> rpc_requests;
     rpc_requests                  _requests[MATCHER_BUCKET_NR];


### PR DESCRIPTION
#### Problem

when prepare or prepare-ack messages are dropped in 2pc, secondary is kicked-out.
#### Solution?

we add rpc retry logic in rpc engine (configured for each rpc code), so that requests are re-sent when timeout is not yet hit and response is not received.
#### usage

```
[task.RPC_PREPARE]
rpc_request_resend_timeout_milliseconds = 8000
```
#### Further problem
- this fixed the issue in our fault injector or UDP network where messages can be dropped individually; however, in tcp network, message drop should not happen unless the connection is lost
- resend will add more workload to the server, which may actually make the situation even worse
#### Discussion
- we can add this feature, but not necessary used in tcp/ip setting (currently for prepare/prepare-ack).
- TODO - need a better failure model for different networks (will do in next pr)
-  TODO - initial problem is not solved yet - should be the throttling issue w/o fault injection - to be investigated
