### PR TITLE
optimize and fix message parser

### DIFF
--- a/include/dsn/internal/factory_store.h
+++ b/include/dsn/internal/factory_store.h
@@ -45,7 +45,7 @@ class factory_store
 {
 public:
     template<typename TFactory>
-    static bool register_factory(const char* name, TFactory factory, int type)
+    static bool register_factory(const char* name, TFactory factory, ::dsn::provider_type type)
     {
         factory_entry entry;
         entry.dummy = nullptr;
@@ -55,7 +55,7 @@ public:
     }
 
     template<typename TFactory>
-    static TFactory get_factory(const char* name, int type)
+    static TFactory get_factory(const char* name, ::dsn::provider_type type)
     {
         factory_entry entry;
         if (singleton_store<std::string, factory_entry>::instance().get(std::string(name), entry))
@@ -80,7 +80,7 @@ public:
     }
 
     template<typename T1, typename T2, typename T3, typename T4, typename T5>
-    static TResult* create(const char* name, int type, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
+    static TResult* create(const char* name, ::dsn::provider_type type, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
     {
         typedef TResult* (*TFactory)(T1,T2,T3,T4,T5);
         TFactory f = get_factory<TFactory>(name, type);
@@ -88,7 +88,7 @@ public:
     }
 
     template<typename T1, typename T2, typename T3, typename T4>
-    static TResult* create(const char* name, int type, T1 t1, T2 t2, T3 t3, T4 t4)
+    static TResult* create(const char* name, ::dsn::provider_type type, T1 t1, T2 t2, T3 t3, T4 t4)
     {
         typedef TResult* (*TFactory)(T1,T2,T3,T4);
         TFactory f = get_factory<TFactory>(name, type);
@@ -96,7 +96,7 @@ public:
     }
 
     template<typename T1, typename T2, typename T3>
-    static TResult* create(const char* name, int type, T1 t1, T2 t2, T3 t3)
+    static TResult* create(const char* name, ::dsn::provider_type type, T1 t1, T2 t2, T3 t3)
     {
         typedef TResult* (*TFactory)(T1,T2,T3);
         TFactory f = get_factory<TFactory>(name, type);
@@ -104,7 +104,7 @@ public:
     }
 
     template<typename T1, typename T2>
-    static TResult* create(const char* name, int type, T1 t1, T2 t2)
+    static TResult* create(const char* name, ::dsn::provider_type type, T1 t1, T2 t2)
     {
         typedef TResult* (*TFactory)(T1,T2);
         TFactory f = get_factory<TFactory>(name, type);
@@ -112,14 +112,14 @@ public:
     }
 
     template<typename T1>
-    static TResult* create(const char* name, int type, T1 t1)
+    static TResult* create(const char* name, ::dsn::provider_type type, T1 t1)
     {
         typedef TResult* (*TFactory)(T1);
         TFactory f = get_factory<TFactory>(name, type);
         return f ? f(t1) : nullptr;
     }
 
-    static TResult* create(const char* name, int type)
+    static TResult* create(const char* name, ::dsn::provider_type type)
     {
         typedef TResult* (*TFactory)();
         TFactory f = get_factory<TFactory>(name, type);
@@ -127,7 +127,7 @@ public:
     }
 
 private:
-    static void report_error(const char* name, int type)
+    static void report_error(const char* name, ::dsn::provider_type type)
     {
         dlog(LOG_LEVEL_FATAL, "factory.store", "cannot find factory '%s' with factory type %s", name, type == PROVIDER_TYPE_MAIN ? "provider" : "aspect");
 
@@ -150,7 +150,7 @@ private:
     {
         TResult* dummy;
         void*    factory;
-        int      type;
+        ::dsn::provider_type  type;
     };
 };
 

--- a/include/dsn/internal/network.h
+++ b/include/dsn/internal/network.h
@@ -120,7 +120,10 @@ namespace dsn {
         //  (1) extracing blob from a RPC request message for low layer'
         //  (2) parsing a incoming blob message to get the rpc_message
         //
-        std::shared_ptr<message_parser> new_message_parser();
+        std::unique_ptr<message_parser> new_message_parser();
+
+        // for in-place new message parser
+        std::pair<message_parser::factory2, size_t> get_message_parser_info();
 
         rpc_engine* engine() const { return _engine; }
         int max_buffer_block_count_per_send() const { return _max_buffer_block_count_per_send; }
@@ -187,7 +190,7 @@ namespace dsn {
         rpc_session(
             connection_oriented_network& net,
             ::dsn::rpc_address remote_addr,
-            std::shared_ptr<message_parser>& parser,
+            std::unique_ptr<message_parser>&& parser,
             bool is_client
             );
         virtual ~rpc_session();
@@ -245,7 +248,7 @@ namespace dsn {
         connection_oriented_network        &_net;
         ::dsn::rpc_address                 _remote_addr;
         int                                _max_buffer_block_count_per_send;        
-        std::shared_ptr<dsn::message_parser> _parser;
+        std::unique_ptr<dsn::message_parser> _parser;
 
         // messages are currently being sent
         // also locked by _lock later

--- a/include/dsn/ports.h
+++ b/include/dsn/ports.h
@@ -85,9 +85,15 @@ __pragma(warning(disable:4127))
 // common utilities
 # include <atomic>
 
-// common macros
-#define PROVIDER_TYPE_MAIN 0
-#define PROVIDER_TYPE_ASPECT 1
+// common macros and data structures
+namespace dsn 
+{
+    enum provider_type
+    {
+        PROVIDER_TYPE_MAIN = 0,
+        PROVIDER_TYPE_ASPECT = 1
+    };
+}
 
 # ifndef TIME_MS_MAX
 # define TIME_MS_MAX UINT_MAX

--- a/include/dsn/thrift_helper.h
+++ b/include/dsn/thrift_helper.h
@@ -262,7 +262,7 @@ namespace dsn {
     public:
         static void register_parser()
         {
-            ::dsn::tools::register_component_provider<thrift_binary_message_parser>("thrift");
+            ::dsn::tools::register_message_header_parser<thrift_binary_message_parser>(NET_HDR_THRIFT);
         }
 
     private:

--- a/include/dsn/tool_api.h
+++ b/include/dsn/tool_api.h
@@ -114,39 +114,38 @@ public:
 
 namespace internal_use_only
 {
-    bool register_component_provider(const char* name, timer_service::factory f, int type);
-    bool register_component_provider(const char* name, task_queue::factory f, int type);
-    bool register_component_provider(const char* name, task_worker::factory f, int type);
-    bool register_component_provider(const char* name, admission_controller::factory f, int type);
-    bool register_component_provider(const char* name, lock_provider::factory f, int type);
-    bool register_component_provider(const char* name, lock_nr_provider::factory f, int type);
-    bool register_component_provider(const char* name, rwlock_nr_provider::factory f, int type);
-    bool register_component_provider(const char* name, semaphore_provider::factory f, int type);
-    bool register_component_provider(const char* name, network::factory f, int type);
-    bool register_component_provider(const char* name, aio_provider::factory f, int type);
-    bool register_component_provider(const char* name, env_provider::factory f, int type);
-    bool register_component_provider(const char* name, perf_counter::factory f, int type);
-    bool register_component_provider(const char* name, logging_provider::factory f, int type);
-    bool register_component_provider(const char* name, memory_provider::factory f, int type);
-    bool register_component_provider(const char* name, nfs_node::factory f, int type);
-    bool register_component_provider(const char* name, message_parser::factory f, int type);
-    
-    bool register_toollet(const char* name, toollet::factory f, int type);
-    bool register_tool(const char* name, tool_app::factory f, int type);
-    toollet* get_toollet(const char* name, int type);
+    bool register_component_provider(const char* name, timer_service::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, task_queue::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, task_worker::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, admission_controller::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, lock_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, lock_nr_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, rwlock_nr_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, semaphore_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, network::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, aio_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, env_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, perf_counter::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, logging_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, memory_provider::factory f, ::dsn::provider_type type);
+    bool register_component_provider(const char* name, nfs_node::factory f, ::dsn::provider_type type);
+    bool register_component_provider(network_header_format fmt, message_parser::factory f, message_parser::factory2 f2, size_t sz);
+    bool register_toollet(const char* name, toollet::factory f, ::dsn::provider_type type);
+    bool register_tool(const char* name, tool_app::factory f, ::dsn::provider_type type);
+    toollet* get_toollet(const char* name, ::dsn::provider_type type);
 }
 
 extern join_point<void, configuration_ptr> sys_init_before_app_created;
 extern join_point<void, configuration_ptr> sys_init_after_app_created;
 extern join_point<void, sys_exit_type>     sys_exit;
 
-template <typename T> bool register_component_provider(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, PROVIDER_TYPE_MAIN); }
-template <typename T> bool register_component_aspect(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, PROVIDER_TYPE_ASPECT); }
-template <typename T> bool register_message_header_parser(network_header_format fmt) { return internal_use_only::register_component_provider(fmt.to_string(), T::template create<T>, PROVIDER_TYPE_MAIN); }
+template <typename T> bool register_component_provider(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, ::dsn::PROVIDER_TYPE_MAIN); }
+template <typename T> bool register_component_aspect(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, ::dsn::PROVIDER_TYPE_ASPECT); }
+template <typename T> bool register_message_header_parser(network_header_format fmt);
 
-template <typename T> bool register_toollet(const char* name) { return internal_use_only::register_toollet(name, toollet::template create<T>, 0); }
-template <typename T> bool register_tool(const char* name) { return internal_use_only::register_tool(name, tool_app::template create<T>, 0); }
-template <typename T> T* get_toollet(const char* name) { return (T*)internal_use_only::get_toollet(name, 0); }
+template <typename T> bool register_toollet(const char* name) { return internal_use_only::register_toollet(name, toollet::template create<T>, ::dsn::PROVIDER_TYPE_MAIN); }
+template <typename T> bool register_tool(const char* name) { return internal_use_only::register_tool(name, tool_app::template create<T>, ::dsn::PROVIDER_TYPE_MAIN); }
+template <typename T> T* get_toollet(const char* name) { return (T*)internal_use_only::get_toollet(name, ::dsn::PROVIDER_TYPE_MAIN); }
 tool_app* get_current_tool();
 configuration_ptr config();
 const service_spec& spec();
@@ -154,7 +153,10 @@ const char* get_service_node_name(service_node* node);
 bool is_engine_ready();
 
 // --------- inline implementation -----------------------------
-
+template <typename T> bool register_message_header_parser(network_header_format fmt) 
+{
+    return internal_use_only::register_component_provider(fmt, T::template create<T>, T::template create2<T>, sizeof(T));
+}
 
 }} // end namespace dsn::tools
 

--- a/src/core/core/message_parser.cpp
+++ b/src/core/core/message_parser.cpp
@@ -43,10 +43,13 @@
 
 namespace dsn {
 
-    message_parser::message_parser(int buffer_block_size)
+    message_parser::message_parser(int buffer_block_size, bool is_write_only)
         : _buffer_block_size(buffer_block_size)
     {
-        create_new_buffer(buffer_block_size);
+        if (!is_write_only)
+        {
+            create_new_buffer(buffer_block_size);
+        }
     }
 
     void message_parser::create_new_buffer(int sz)
@@ -94,13 +97,39 @@ namespace dsn {
         return _read_buffer.length() - _read_buffer_occupied;
     }
 
-    //-------------------- dsn message --------------------
-
-    dsn_message_parser::dsn_message_parser(int buffer_block_size)
-        : message_parser(buffer_block_size)
+    //-------------------- msg parser manager --------------------
+    message_parser_manager::message_parser_manager()
     {
+        _factory_vec.resize(network_header_format::max_value());
     }
 
+    void message_parser_manager::register_factory(network_header_format fmt, message_parser::factory f, message_parser::factory2 f2, size_t sz)
+    {
+        if (fmt >= _factory_vec.size())
+        {
+            _factory_vec.resize(fmt + 1);
+        }
+
+        parser_factory_info& info = _factory_vec[fmt];
+        info.fmt = fmt;
+        info.factory = f;
+        info.factory2 = f2;
+        info.parser_size = sz;
+    }
+
+    message_parser* message_parser_manager::create_parser(network_header_format fmt, int buffer_blk_size, bool is_write_only)
+    {
+        parser_factory_info& info = _factory_vec[fmt];
+        return info.factory(buffer_blk_size, is_write_only);
+    }
+
+    //-------------------- dsn message --------------------
+
+    dsn_message_parser::dsn_message_parser(int buffer_block_size, bool is_write_only)
+        : message_parser(buffer_block_size, is_write_only)
+    {
+    }
+    
     message_ex* dsn_message_parser::get_message_on_receive(int read_length, /*out*/ int& read_next)
     {
         mark_read(read_length);

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -422,14 +422,14 @@ namespace dsn {
     {
         const service_spec& spec = service_engine::fast_instance().spec();
         auto net = utils::factory_store<network>::create(
-            netcs.factory_name.c_str(), PROVIDER_TYPE_MAIN, this, nullptr);
+            netcs.factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, this, nullptr);
         net->reset_parser(netcs.hdr_format, netcs.message_buffer_block_size);
 
         for (auto it = spec.network_aspects.begin();
             it != spec.network_aspects.end();
             it++)
         {
-            net = utils::factory_store<network>::create(it->c_str(), PROVIDER_TYPE_ASPECT, this, net);
+            net = utils::factory_store<network>::create(it->c_str(), ::dsn::PROVIDER_TYPE_ASPECT, this, net);
         }
 
         // start the net

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -439,12 +439,12 @@ DSN_API dsn_handle_t dsn_exlock_create(bool recursive)
     if (recursive)
     {
         ::dsn::lock_provider* last = ::dsn::utils::factory_store< ::dsn::lock_provider>::create(
-            ::dsn::service_engine::fast_instance().spec().lock_factory_name.c_str(), PROVIDER_TYPE_MAIN, nullptr);
+            ::dsn::service_engine::fast_instance().spec().lock_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, nullptr);
 
         // TODO: perf opt by saving the func ptrs somewhere
         for (auto& s : ::dsn::service_engine::fast_instance().spec().lock_aspects)
         {
-            last = ::dsn::utils::factory_store< ::dsn::lock_provider>::create(s.c_str(), PROVIDER_TYPE_ASPECT, last);
+            last = ::dsn::utils::factory_store< ::dsn::lock_provider>::create(s.c_str(), ::dsn::PROVIDER_TYPE_ASPECT, last);
         }
 
         return (dsn_handle_t)dynamic_cast< ::dsn::ilock*>(last);
@@ -452,12 +452,12 @@ DSN_API dsn_handle_t dsn_exlock_create(bool recursive)
     else
     {
         ::dsn::lock_nr_provider* last = ::dsn::utils::factory_store< ::dsn::lock_nr_provider>::create(
-            ::dsn::service_engine::fast_instance().spec().lock_nr_factory_name.c_str(), PROVIDER_TYPE_MAIN, nullptr);
+            ::dsn::service_engine::fast_instance().spec().lock_nr_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, nullptr);
 
         // TODO: perf opt by saving the func ptrs somewhere
         for (auto& s : ::dsn::service_engine::fast_instance().spec().lock_nr_aspects)
         {
-            last = ::dsn::utils::factory_store< ::dsn::lock_nr_provider>::create(s.c_str(), PROVIDER_TYPE_ASPECT, last);
+            last = ::dsn::utils::factory_store< ::dsn::lock_nr_provider>::create(s.c_str(), ::dsn::PROVIDER_TYPE_ASPECT, last);
         }
 
         return (dsn_handle_t)dynamic_cast< ::dsn::ilock*>(last);
@@ -495,12 +495,12 @@ DSN_API void dsn_exlock_unlock(dsn_handle_t l)
 DSN_API dsn_handle_t dsn_rwlock_nr_create()
 {
     ::dsn::rwlock_nr_provider* last = ::dsn::utils::factory_store< ::dsn::rwlock_nr_provider>::create(
-        ::dsn::service_engine::fast_instance().spec().rwlock_nr_factory_name.c_str(), PROVIDER_TYPE_MAIN, nullptr);
+        ::dsn::service_engine::fast_instance().spec().rwlock_nr_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, nullptr);
 
     // TODO: perf opt by saving the func ptrs somewhere
     for (auto& s : ::dsn::service_engine::fast_instance().spec().rwlock_nr_aspects)
     {
-        last = ::dsn::utils::factory_store< ::dsn::rwlock_nr_provider>::create(s.c_str(), PROVIDER_TYPE_ASPECT, last);
+        last = ::dsn::utils::factory_store< ::dsn::rwlock_nr_provider>::create(s.c_str(), ::dsn::PROVIDER_TYPE_ASPECT, last);
     }
     return (dsn_handle_t)(last);
 }
@@ -538,13 +538,13 @@ DSN_API void dsn_rwlock_nr_unlock_write(dsn_handle_t l)
 DSN_API dsn_handle_t dsn_semaphore_create(int initial_count)
 {
     ::dsn::semaphore_provider* last = ::dsn::utils::factory_store< ::dsn::semaphore_provider>::create(
-        ::dsn::service_engine::fast_instance().spec().semaphore_factory_name.c_str(), PROVIDER_TYPE_MAIN, initial_count, nullptr);
+        ::dsn::service_engine::fast_instance().spec().semaphore_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, initial_count, nullptr);
 
     // TODO: perf opt by saving the func ptrs somewhere
     for (auto& s : ::dsn::service_engine::fast_instance().spec().semaphore_aspects)
     {
         last = ::dsn::utils::factory_store< ::dsn::semaphore_provider>::create(
-            s.c_str(), PROVIDER_TYPE_ASPECT, initial_count, last);
+            s.c_str(), ::dsn::PROVIDER_TYPE_ASPECT, initial_count, last);
     }
     return (dsn_handle_t)(last);
 }
@@ -1178,7 +1178,7 @@ bool run(const char* config_file, const char* config_arguments, bool sleep_after
     dsn::utils::filesystem::create_directory(spec.dir_log);
     
     // init tools
-    dsn_all.tool = ::dsn::utils::factory_store< ::dsn::tools::tool_app>::create(spec.tool.c_str(), 0, spec.tool.c_str());
+    dsn_all.tool = ::dsn::utils::factory_store< ::dsn::tools::tool_app>::create(spec.tool.c_str(), ::dsn::PROVIDER_TYPE_MAIN, spec.tool.c_str());
     dsn_all.tool->install(spec);
 
     // init app specs
@@ -1190,7 +1190,7 @@ bool run(const char* config_file, const char* config_arguments, bool sleep_after
 
     // init tool memory
     dsn_all.memory = ::dsn::utils::factory_store< ::dsn::memory_provider>::create(
-        spec.tools_memory_factory_name.c_str(), PROVIDER_TYPE_MAIN);
+        spec.tools_memory_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN);
 
     // prepare minimum necessary
     ::dsn::service_engine::fast_instance().init_before_toollets(spec);
@@ -1201,7 +1201,7 @@ bool run(const char* config_file, const char* config_arguments, bool sleep_after
     // init toollets
     for (auto it = spec.toollets.begin(); it != spec.toollets.end(); ++it)
     {
-        auto tlet = dsn::tools::internal_use_only::get_toollet(it->c_str(), 0);
+        auto tlet = dsn::tools::internal_use_only::get_toollet(it->c_str(), ::dsn::PROVIDER_TYPE_MAIN);
         dassert(tlet, "toolet not found");
         tlet->install(spec);
     }

--- a/src/core/core/service_engine.cpp
+++ b/src/core/core/service_engine.cpp
@@ -129,7 +129,7 @@ error_code service_node::init_io_engine(io_engine& io, ioe_mode mode)
     {
         io.disk = new disk_engine(this);
         aio_provider* aio = factory_store<aio_provider>::create(
-            spec.aio_factory_name.c_str(), PROVIDER_TYPE_MAIN, io.disk, nullptr);
+            spec.aio_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, io.disk, nullptr);
         for (auto it = spec.aio_aspects.begin();
             it != spec.aio_aspects.end();
             it++)
@@ -405,14 +405,14 @@ void service_engine::init_before_toollets(const service_spec& spec)
 
     // init common providers (first half)
     _logging = factory_store<logging_provider>::create(
-        spec.logging_factory_name.c_str(), PROVIDER_TYPE_MAIN, spec.dir_log.c_str()
+        spec.logging_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, spec.dir_log.c_str()
         );
     _memory = factory_store<memory_provider>::create(
-        spec.memory_factory_name.c_str(), PROVIDER_TYPE_MAIN
+        spec.memory_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN
         );
     perf_counters::instance().register_factory(
         factory_store<perf_counter>::get_factory<perf_counter::factory>(
-        spec.perf_counter_factory_name.c_str(), PROVIDER_TYPE_MAIN
+        spec.perf_counter_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN
         )
         );
 }

--- a/src/core/core/task_engine.cpp
+++ b/src/core/core/task_engine.cpp
@@ -62,12 +62,12 @@ void task_worker_pool::create()
     int qCount = _spec.partitioned ?  _spec.worker_count : 1;
     for (int i = 0; i < qCount; i++)
     {
-        task_queue* q = factory_store<task_queue>::create(_spec.queue_factory_name.c_str(), PROVIDER_TYPE_MAIN, this, i, nullptr);
+        task_queue* q = factory_store<task_queue>::create(_spec.queue_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, this, i, nullptr);
         for (auto it = _spec.queue_aspects.begin();
             it != _spec.queue_aspects.end();
             it++)
         {
-            q = factory_store<task_queue>::create(it->c_str(), PROVIDER_TYPE_ASPECT, this, i, q);
+            q = factory_store<task_queue>::create(it->c_str(), ::dsn::PROVIDER_TYPE_ASPECT, this, i, q);
         }
         _queues.push_back(q);
 
@@ -96,12 +96,12 @@ void task_worker_pool::create()
     for (int i = 0; i < _spec.worker_count; i++)
     {
         auto q = _queues[qCount == 1 ? 0 : i];
-        task_worker* worker = factory_store<task_worker>::create(_spec.worker_factory_name.c_str(), PROVIDER_TYPE_MAIN, this, q, i, nullptr);
+        task_worker* worker = factory_store<task_worker>::create(_spec.worker_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, this, q, i, nullptr);
         for (auto it = _spec.worker_aspects.begin();
             it != _spec.worker_aspects.end();
             it++)
         {
-            worker = factory_store<task_worker>::create(it->c_str(), PROVIDER_TYPE_ASPECT, this, q, i, worker);
+            worker = factory_store<task_worker>::create(it->c_str(), ::dsn::PROVIDER_TYPE_ASPECT, this, q, i, worker);
         }
         task_worker::on_create.execute(worker);
         q->set_owner_worker(spec().partitioned ? worker : nullptr);

--- a/src/core/core/tool_api.cpp
+++ b/src/core/core/tool_api.cpp
@@ -164,97 +164,98 @@ namespace dsn {
 
         namespace internal_use_only
         {
-            bool register_toollet(const char* name, toollet::factory f, int type)
+            bool register_toollet(const char* name, toollet::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<toollet>::register_factory(name, f, type);
             }
 
-            bool register_tool(const char* name, tool_app::factory f, int type)
+            bool register_tool(const char* name, tool_app::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<tool_app>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, timer_service::factory f, int type)
+            bool register_component_provider(const char* name, timer_service::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<timer_service>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, task_queue::factory f, int type)
+            bool register_component_provider(const char* name, task_queue::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<task_queue>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, task_worker::factory f, int type)
+            bool register_component_provider(const char* name, task_worker::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<task_worker>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, admission_controller::factory f, int type)
+            bool register_component_provider(const char* name, admission_controller::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<admission_controller>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, lock_provider::factory f, int type)
+            bool register_component_provider(const char* name, lock_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<lock_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, lock_nr_provider::factory f, int type)
+            bool register_component_provider(const char* name, lock_nr_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<lock_nr_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, rwlock_nr_provider::factory f, int type)
+            bool register_component_provider(const char* name, rwlock_nr_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<rwlock_nr_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, semaphore_provider::factory f, int type)
+            bool register_component_provider(const char* name, semaphore_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<semaphore_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, network::factory f, int type)
+            bool register_component_provider(const char* name, network::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<network>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, aio_provider::factory f, int type)
+            bool register_component_provider(const char* name, aio_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<aio_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, env_provider::factory f, int type)
+            bool register_component_provider(const char* name, env_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<env_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, perf_counter::factory f, int type)
+            bool register_component_provider(const char* name, perf_counter::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<perf_counter>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, nfs_node::factory f, int type)
+            bool register_component_provider(const char* name, nfs_node::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<nfs_node>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, logging_provider::factory f, int type)
+            bool register_component_provider(const char* name, logging_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<logging_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, memory_provider::factory f, int type)
+            bool register_component_provider(const char* name, memory_provider::factory f, ::dsn::provider_type type)
             {
                 return dsn::utils::factory_store<memory_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(const char* name, message_parser::factory f, int type)
+            bool register_component_provider(network_header_format fmt, message_parser::factory f, message_parser::factory2 f2, size_t sz)
             {
-                return dsn::utils::factory_store<message_parser>::register_factory(name, f, type);
+                message_parser_manager::instance().register_factory(fmt, f, f2, sz);
+                return true;
             }
 
-            toollet* get_toollet(const char* name, int type)
+            toollet* get_toollet(const char* name, ::dsn::provider_type type)
             {
                 toollet* tlt = nullptr;
                 if (utils::singleton_store<std::string, toollet*>::instance().get(name, tlt))

--- a/src/core/tools/common/asio_net_provider.h
+++ b/src/core/tools/common/asio_net_provider.h
@@ -69,6 +69,7 @@ namespace dsn {
             asio_udp_provider(rpc_engine* srv, network* inner_provider)
                 : network(srv, inner_provider)
             {
+                _recv_parser = std::move(new_message_parser());
             }
 
             void send_message(message_ex* request) override;
@@ -93,6 +94,7 @@ namespace dsn {
             std::shared_ptr<boost::asio::ip::udp::socket>   _socket;
             std::vector<std::shared_ptr<std::thread>>       _workers;
             ::dsn::rpc_address                              _address;
+            std::unique_ptr<message_parser>                 _recv_parser;
 
             static const size_t max_udp_packet_size = 450;
         };

--- a/src/core/tools/common/asio_rpc_session.cpp
+++ b/src/core/tools/common/asio_rpc_session.cpp
@@ -149,11 +149,11 @@ namespace dsn {
             asio_network_provider& net,
             ::dsn::rpc_address remote_addr,
             std::shared_ptr<boost::asio::ip::tcp::socket>& socket,
-            std::shared_ptr<message_parser>& parser,
+            std::unique_ptr<message_parser>&& parser,
             bool is_client
             )
             :
-            rpc_session(net, remote_addr, parser, is_client),
+            rpc_session(net, remote_addr, std::move(parser), is_client),
             _socket(socket)
         {
             set_options();

--- a/src/core/tools/common/asio_rpc_session.h
+++ b/src/core/tools/common/asio_rpc_session.h
@@ -51,7 +51,7 @@ namespace dsn {
                 asio_network_provider& net,
                 ::dsn::rpc_address remote_addr,
                 std::shared_ptr<boost::asio::ip::tcp::socket>& socket,
-                std::shared_ptr<message_parser>& parser,
+                std::unique_ptr<message_parser>&& parser,
                 bool is_client
                 );
             virtual ~asio_rpc_session();

--- a/src/core/tools/common/network.sim.cpp
+++ b/src/core/tools/common/network.sim.cpp
@@ -53,9 +53,9 @@ namespace dsn { namespace tools {
     sim_client_session::sim_client_session(
         sim_network_provider& net, 
         ::dsn::rpc_address remote_addr, 
-        std::shared_ptr<message_parser>& parser
+        std::unique_ptr<message_parser>&& parser
         )
-        : rpc_session(net, remote_addr, parser, true)
+        : rpc_session(net, remote_addr, std::move(parser), true)
     {}
 
     void sim_client_session::connect() 
@@ -100,8 +100,8 @@ namespace dsn { namespace tools {
                 if (nullptr == server_session)
                 {
                     rpc_session_ptr cptr = this;
-                    auto parser = _net.new_message_parser();
-                    server_session = new sim_server_session(*rnet, _net.address(), cptr, parser);
+                    server_session = new sim_server_session(*rnet, _net.address(), 
+                        cptr, _net.new_message_parser());
                     rnet->on_server_session_accepted(server_session);
                 }
 
@@ -125,9 +125,9 @@ namespace dsn { namespace tools {
         sim_network_provider& net, 
         ::dsn::rpc_address remote_addr,
         rpc_session_ptr& client,
-        std::shared_ptr<message_parser>& parser
+        std::unique_ptr<message_parser>&& parser
         )
-        : rpc_session(net, remote_addr, parser, false)
+        : rpc_session(net, remote_addr, std::move(parser), false)
     {
         _client = client;
     }

--- a/src/core/tools/common/network.sim.h
+++ b/src/core/tools/common/network.sim.h
@@ -46,7 +46,7 @@ namespace dsn { namespace tools {
         sim_client_session(
             sim_network_provider& net, 
             ::dsn::rpc_address remote_addr, 
-            std::shared_ptr<message_parser>& parser
+            std::unique_ptr<message_parser>&& parser
             );
 
         virtual void connect();
@@ -65,7 +65,7 @@ namespace dsn { namespace tools {
             sim_network_provider& net, 
             ::dsn::rpc_address remote_addr, 
             rpc_session_ptr& client, 
-            std::shared_ptr<message_parser>& parser
+            std::unique_ptr<message_parser>&& parser
             );
 
         virtual void send(uint64_t signature) override;
@@ -92,8 +92,7 @@ namespace dsn { namespace tools {
 
         virtual rpc_session_ptr create_client_session(::dsn::rpc_address server_addr)
         {
-            auto parser = new_message_parser();
-            return rpc_session_ptr(new sim_client_session(*this, server_addr, parser));
+            return rpc_session_ptr(new sim_client_session(*this, server_addr, new_message_parser()));
         }
 
         uint32_t net_delay_milliseconds() const;

--- a/src/core/tools/common/providers.common.cpp
+++ b/src/core/tools/common/providers.common.cpp
@@ -67,7 +67,7 @@ namespace dsn {
             register_component_provider<simple_task_queue>("dsn::tools::simple_task_queue");
             register_component_provider<simple_timer_service>("dsn::tools::simple_timer_service");
             
-            register_message_header_parser<dsn_message_parser>("NET_HDR_DSN");
+            register_message_header_parser<dsn_message_parser>(NET_HDR_DSN);
 #if defined(_WIN32)
             register_component_provider<native_win_aio_provider>("dsn::tools::native_aio_provider");
 #elif defined(__linux__)

--- a/src/core/tools/hpc/hpc_network_provider.bsd.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.bsd.cpp
@@ -165,8 +165,6 @@ namespace dsn
 
         rpc_session_ptr hpc_network_provider::create_client_session(::dsn::rpc_address server_addr)
         {
-            auto parser = new_message_parser();
-
             struct sockaddr_in addr;
             addr.sin_family = AF_INET;
             addr.sin_addr.s_addr = INADDR_ANY;
@@ -174,7 +172,7 @@ namespace dsn
 
             auto sock = create_tcp_socket(&addr);
             dassert(sock != -1, "create client tcp socket failed!");
-            auto client = new hpc_rpc_session(sock, parser, *this, server_addr, true);
+            auto client = new hpc_rpc_session(sock, new_message_parser(), *this, server_addr, true);
             rpc_session_ptr c(client);
             client->bind_looper(_looper, true);
             return c;
@@ -191,8 +189,7 @@ namespace dsn
                 {
                     ::dsn::rpc_address client_addr(ntohl(addr.sin_addr.s_addr), ntohs(addr.sin_port));
 
-                    auto parser = new_message_parser();
-                    auto rs = new hpc_rpc_session(s, parser, *this, client_addr, false);
+                    auto rs = new hpc_rpc_session(s, new_message_parser(), *this, client_addr, false);
                     rpc_session_ptr s1(rs);
 
                     rs->bind_looper(_looper);
@@ -444,7 +441,7 @@ namespace dsn
         // client
         hpc_rpc_session::hpc_rpc_session(
             socket_t sock,
-            std::shared_ptr<dsn::message_parser>& parser,
+            std::unique_ptr<message_parser>&& parser,
             connection_oriented_network& net,
             ::dsn::rpc_address remote_addr,
             bool is_client

--- a/src/core/tools/hpc/hpc_network_provider.bsd.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.bsd.cpp
@@ -446,7 +446,7 @@ namespace dsn
             ::dsn::rpc_address remote_addr,
             bool is_client
             )
-            : rpc_session(net, remote_addr, parser, is_client),
+            : rpc_session(net, remote_addr, std::move(parser), is_client),
              _socket(sock)
         {
             dassert(sock != -1, "invalid given socket handle");

--- a/src/core/tools/hpc/hpc_network_provider.h
+++ b/src/core/tools/hpc/hpc_network_provider.h
@@ -105,7 +105,7 @@ namespace dsn {
         public:
             hpc_rpc_session(
                 socket_t sock,
-                std::shared_ptr<dsn::message_parser>& parser,
+                std::unique_ptr<message_parser>&& parser,
                 connection_oriented_network& net,
                 ::dsn::rpc_address remote_addr,
                 bool is_client

--- a/src/core/tools/hpc/hpc_network_provider.linux.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.linux.cpp
@@ -165,8 +165,6 @@ namespace dsn
 
         rpc_session_ptr hpc_network_provider::create_client_session(::dsn::rpc_address server_addr)
         {
-            auto parser = new_message_parser();
-
             struct sockaddr_in addr;
             addr.sin_family = AF_INET;
             addr.sin_addr.s_addr = INADDR_ANY;
@@ -174,7 +172,7 @@ namespace dsn
 
             auto sock = create_tcp_socket(&addr);
             dassert(sock != -1, "create client tcp socket failed!");
-            auto client = new hpc_rpc_session(sock, parser, *this, server_addr, true);
+            auto client = new hpc_rpc_session(sock, new_message_parser(), *this, server_addr, true);
             rpc_session_ptr c(client);
             client->bind_looper(_looper, true);
             return c;
@@ -191,8 +189,7 @@ namespace dsn
                 {
                     ::dsn::rpc_address client_addr(ntohl(addr.sin_addr.s_addr), ntohs(addr.sin_port));
 
-                    auto parser = new_message_parser();
-                    auto rs = new hpc_rpc_session(s, parser, *this, client_addr, false);
+                    auto rs = new hpc_rpc_session(s, new_message_parser(), *this, client_addr, false);
                     rpc_session_ptr s1(rs);
 
                     rs->bind_looper(_looper);
@@ -435,7 +432,7 @@ namespace dsn
 
         hpc_rpc_session::hpc_rpc_session(
             socket_t sock,
-            std::shared_ptr<dsn::message_parser>& parser,
+            std::unique_ptr<message_parser>&& parser,
             connection_oriented_network& net,
             ::dsn::rpc_address remote_addr,
             bool is_client

--- a/src/core/tools/hpc/hpc_network_provider.linux.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.linux.cpp
@@ -437,7 +437,7 @@ namespace dsn
             ::dsn::rpc_address remote_addr,
             bool is_client
             )
-            : rpc_session(net, remote_addr, parser, is_client),
+            : rpc_session(net, remote_addr, std::move(parser), is_client),
              _socket(sock)
         {
             dassert(sock != -1, "invalid given socket handle");

--- a/src/core/tools/hpc/hpc_network_provider.win.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.win.cpp
@@ -243,15 +243,13 @@ namespace dsn
 
         rpc_session_ptr hpc_network_provider::create_client_session(::dsn::rpc_address server_addr)
         {
-            auto parser = new_message_parser();
-
             struct sockaddr_in addr;
             addr.sin_family = AF_INET;
             addr.sin_addr.s_addr = INADDR_ANY;
             addr.sin_port = 0;
 
             auto sock = create_tcp_socket(&addr);
-            auto client = new hpc_rpc_session(sock, parser, *this, server_addr, true);
+            auto client = new hpc_rpc_session(sock, new_message_parser(), *this, server_addr, true);
             rpc_session_ptr c(client);
             client->bind_looper(_looper);
             return c;
@@ -292,8 +290,7 @@ namespace dsn
 
                     ::dsn::rpc_address client_addr(ntohl(addr.sin_addr.s_addr), ntohs(addr.sin_port));
 
-                    auto parser = new_message_parser();
-                    auto s = new hpc_rpc_session(_accept_sock, parser, *this, client_addr, false);
+                    auto s = new hpc_rpc_session(_accept_sock, new_message_parser(), *this, client_addr, false);
                     rpc_session_ptr s1(s);
                     s->bind_looper(_looper);
 
@@ -497,12 +494,12 @@ namespace dsn
 
         hpc_rpc_session::hpc_rpc_session(
             socket_t sock,
-            std::shared_ptr<dsn::message_parser>& parser,
+            std::unique_ptr<message_parser>&& parser,
             connection_oriented_network& net,
             ::dsn::rpc_address remote_addr,
             bool is_client
             )
-            : rpc_session(net, remote_addr, parser, is_client),
+            : rpc_session(net, remote_addr, std::move(parser), is_client),
             _socket(sock)
         {
             _sending_signature = 0;

--- a/src/dist/replication/lib/replica_init.cpp
+++ b/src/dist/replication/lib/replica_init.cpp
@@ -159,7 +159,7 @@ error_code replica::init_app_and_prepare_list(bool create_new)
 {
     dassert(nullptr == _app, "");
 
-    _app.reset(::dsn::utils::factory_store<replication_app_base>::create(_app_type.c_str(), PROVIDER_TYPE_MAIN, this));
+    _app.reset(::dsn::utils::factory_store<replication_app_base>::create(_app_type.c_str(), ::dsn::PROVIDER_TYPE_MAIN, this));
     if (nullptr == _app)
     {
         derror( "%s: app type %s not found", name(), _app_type.c_str());

--- a/src/dist/replication/lib/replication_app_base.cpp
+++ b/src/dist/replication/lib/replication_app_base.cpp
@@ -49,7 +49,7 @@ namespace dsn { namespace replication {
 
 void register_replica_provider(replica_app_factory f, const char* name)
 {
-    ::dsn::utils::factory_store<replication_app_base>::register_factory(name, f, PROVIDER_TYPE_MAIN);
+    ::dsn::utils::factory_store<replication_app_base>::register_factory(name, f, ::dsn::PROVIDER_TYPE_MAIN);
 }
 
 error_code replica_init_info::load(const char* file)


### PR DESCRIPTION
(1) use on-stack message parser for asio udp provider as the parser is created for each send udp message
(2) use std::unique_ptr instead of std::shared_ptr for message parser
(3) use strong typed tool and toollet provide type instead of integer
