### PR TITLE
some fixes

### DIFF
--- a/bin/dsn.templates/cpp/replication/client.h.php
+++ b/bin/dsn.templates/cpp/replication/client.h.php
@@ -34,7 +34,7 @@ foreach ($keys as $k => $v)
  
     // ---------- call <?=$f->get_rpc_code()?> ------------
     // - synchronous  
-    std::pair<::dsn::error_code, <?=$f->get_cpp_return_type()?>> <?=$f->name?>_sync(
+    std::pair< ::dsn::error_code, <?=$f->get_cpp_return_type()?>> <?=$f->name?>_sync(
         const <?=$f->get_first_param()->get_cpp_type()?>& <?=$f->get_first_param()->name?>,
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0)<?=$f->is_write ? "":", ". PHP_EOL."        ::dsn::replication::read_semantic_t read_semantic = ::dsn::replication::read_semantic_t::ReadLastUpdate"?>
         )

--- a/bin/dsn.templates/cpp/single/client.h.php
+++ b/bin/dsn.templates/cpp/single/client.h.php
@@ -26,7 +26,7 @@ public:
     void <?=$f->name?>(
         const <?=$f->get_first_param()->get_cpp_type()?>& <?=$f->get_first_param()->name?>, 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         ::dsn::rpc::call_one_way_typed(server_addr.unwrap_or(_server), 
@@ -34,11 +34,11 @@ public:
     }
 <?php    } else { ?>
     // - synchronous 
-    std::pair<::dsn::error_code, <?=$f->get_cpp_return_type()?>> <?=$f->name?>_sync(
+    std::pair< ::dsn::error_code, <?=$f->get_cpp_return_type()?>> <?=$f->name?>_sync(
         const <?=$f->get_first_param()->get_cpp_type()?>& <?=$f->get_first_param()->name?>, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::wait_and_unwrap<<?=$f->get_cpp_return_type()?>>(
@@ -62,7 +62,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(

--- a/include/dsn/cpp/clientlet.h
+++ b/include/dsn/cpp/clientlet.h
@@ -327,10 +327,10 @@ namespace dsn
 
 
         template<typename TResponse>
-        std::pair<::dsn::error_code, TResponse> wait_and_unwrap(task_ptr task)
+        std::pair< ::dsn::error_code, TResponse> wait_and_unwrap(task_ptr task)
         {
             task->wait();
-            std::pair<::dsn::error_code, TResponse> result;
+            std::pair< ::dsn::error_code, TResponse> result;
             result.first = task->error();
             if (task->error() == ::dsn::ERR_OK)
             {
@@ -340,7 +340,7 @@ namespace dsn
         }
 
         template<typename TResponse, typename TRequest>
-        std::pair<::dsn::error_code, TResponse> call_wait(
+        std::pair< ::dsn::error_code, TResponse> call_wait(
             ::dsn::rpc_address server,
             dsn_task_code_t code,
             const TRequest& req,

--- a/include/dsn/dist/failure_detector/fd.client.h
+++ b/include/dsn/dist/failure_detector/fd.client.h
@@ -50,11 +50,11 @@ public:
 
     // ---------- call RPC_FD_FAILURE_DETECTOR_PING ------------
     // - synchronous 
-    std::pair<::dsn::error_code, beacon_ack> ping_sync(
+    std::pair< ::dsn::error_code, beacon_ack> ping_sync(
         const beacon_msg& beacon, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::wait_and_unwrap<beacon_ack>(
@@ -78,7 +78,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(

--- a/scripts/linux/format.sh
+++ b/scripts/linux/format.sh
@@ -14,7 +14,7 @@ find . -name '*.h' \
     | grep -v '^\./\.' \
     | grep -v '^\./builder' \
     | grep -v '^\./scripts/.*/format.sh' \
-    | xargs grep -n '	'
+    | xargs grep -n '	\|<::'
 
 if [ $? -eq 0 ]; then
     echo "ERROR: check format failed"

--- a/src/apps/echo/echo.client.h
+++ b/src/apps/echo/echo.client.h
@@ -49,11 +49,11 @@ public:
 
     // ---------- call RPC_ECHO_ECHO_PING ------------
     // - synchronous 
-    std::pair<::dsn::error_code, std::string> ping_sync(
+    std::pair< ::dsn::error_code, std::string> ping_sync(
         const std::string& val, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<std::string>(
             ::dsn::rpc::call(
@@ -76,7 +76,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(

--- a/src/apps/nfs/nfs_client.h
+++ b/src/apps/nfs/nfs_client.h
@@ -49,11 +49,11 @@ public:
 
     // ---------- call RPC_NFS_NFS_COPY ------------
     // - synchronous 
-    std::pair<::dsn::error_code, copy_response> copy_sync(
+    std::pair< ::dsn::error_code, copy_response> copy_sync(
         const copy_request& request, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<copy_response>(
             ::dsn::rpc::call(
@@ -76,7 +76,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(
@@ -93,11 +93,11 @@ public:
 
     // ---------- call RPC_NFS_NFS_GET_FILE_SIZE ------------
     // - synchronous 
-    std::pair<::dsn::error_code, get_file_size_response> get_file_size_sync(
+    std::pair< ::dsn::error_code, get_file_size_response> get_file_size_sync(
         const get_file_size_request& request, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<get_file_size_response>(
             ::dsn::rpc::call(
@@ -120,7 +120,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(

--- a/src/apps/skv/simple_kv.client.h
+++ b/src/apps/skv/simple_kv.client.h
@@ -52,7 +52,7 @@ public:
     virtual uint64_t get_key_hash(const kv_pair& key) = 0;
     // ---------- call RPC_SIMPLE_KV_SIMPLE_KV_READ ------------
     // - synchronous 
-    std::pair<::dsn::error_code, std::string> read_sync(
+    std::pair< ::dsn::error_code, std::string> read_sync(
         const std::string& key, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         ::dsn::replication::read_semantic read_semantic = ::dsn::replication::read_semantic::ReadLastUpdate 
@@ -95,7 +95,7 @@ public:
     }    
     // ---------- call RPC_SIMPLE_KV_SIMPLE_KV_WRITE ------------
     // - synchronous 
-    std::pair<::dsn::error_code, int32_t> write_sync(
+    std::pair< ::dsn::error_code, int32_t> write_sync(
         const kv_pair& pr, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0) 
         )
@@ -134,7 +134,7 @@ public:
     }    
     // ---------- call RPC_SIMPLE_KV_SIMPLE_KV_APPEND ------------
     // - synchronous 
-    std::pair<::dsn::error_code, int32_t> append_sync(
+    std::pair< ::dsn::error_code, int32_t> append_sync(
         const kv_pair& pr, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0) 
         )

--- a/src/core/tools/common/asio_net_provider.cpp
+++ b/src/core/tools/common/asio_net_provider.cpp
@@ -160,7 +160,7 @@ namespace dsn {
 
         void asio_udp_provider::do_receive()
         {
-            std::shared_ptr<::boost::asio::ip::udp::endpoint> send_endpoint(new ::boost::asio::ip::udp::endpoint);
+            std::shared_ptr< ::boost::asio::ip::udp::endpoint> send_endpoint(new ::boost::asio::ip::udp::endpoint);
 
             _recv_parser->truncate_read();
             auto buffer_ptr = _recv_parser->read_buffer_ptr(max_udp_packet_size);

--- a/src/dist/cluster_scheduler/scheduler_providers/scheduler_providers.cpp
+++ b/src/dist/cluster_scheduler/scheduler_providers/scheduler_providers.cpp
@@ -42,7 +42,7 @@ namespace dsn {
                 const char * name,
                 ::dsn::dist::cluster_scheduler::factory f)
         {
-            return dsn::utils::factory_store<::dsn::dist::cluster_scheduler>::register_factory(
+            return dsn::utils::factory_store< ::dsn::dist::cluster_scheduler>::register_factory(
                     name,
                     f,
                     PROVIDER_TYPE_MAIN);
@@ -53,11 +53,11 @@ namespace dsn {
             // register all cluster provider
             register_component_provider(
                     "dsn::dist::kubernetes_cluster_scheduler",
-                    ::dsn::dist::cluster_scheduler::create<::dsn::dist::kubernetes_cluster_scheduler>
+                    ::dsn::dist::cluster_scheduler::create< ::dsn::dist::kubernetes_cluster_scheduler>
                     );
             register_component_provider(
                     "dsn::dist::docker_scheduler",
-                    ::dsn::dist::cluster_scheduler::create<::dsn::dist::docker_scheduler>
+                    ::dsn::dist::cluster_scheduler::create< ::dsn::dist::docker_scheduler>
                     );
         }
 

--- a/src/dist/deployment_service/deploy_svc.client.h
+++ b/src/dist/deployment_service/deploy_svc.client.h
@@ -15,11 +15,11 @@ public:
 
     // ---------- call RPC_DEPLOY_SVC_DEPLOY_SVC_DEPLOY ------------
     // - synchronous 
-    std::pair<::dsn::error_code, deploy_info> deploy_sync(
+    std::pair< ::dsn::error_code, deploy_info> deploy_sync(
         const deploy_request& req, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<deploy_info>(
             ::dsn::rpc::call(
@@ -42,7 +42,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(
@@ -59,13 +59,13 @@ public:
 
     // ---------- call RPC_DEPLOY_SVC_DEPLOY_SVC_UNDEPLOY ------------
     // - synchronous 
-    std::pair<::dsn::error_code, ::dsn::error_code> undeploy_sync(
+    std::pair< ::dsn::error_code, ::dsn::error_code> undeploy_sync(
         const std::string& service_url, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
-        return ::dsn::rpc::wait_and_unwrap<::dsn::error_code>(
+        return ::dsn::rpc::wait_and_unwrap< ::dsn::error_code>(
             ::dsn::rpc::call(
                 server_addr.unwrap_or(_server),
                 RPC_DEPLOY_SVC_DEPLOY_SVC_UNDEPLOY,
@@ -86,7 +86,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(
@@ -103,11 +103,11 @@ public:
 
     // ---------- call RPC_DEPLOY_SVC_DEPLOY_SVC_GET_SERVICE_LIST ------------
     // - synchronous 
-    std::pair<::dsn::error_code, deploy_info_list> get_service_list_sync(
+    std::pair< ::dsn::error_code, deploy_info_list> get_service_list_sync(
         const std::string& package_id, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<deploy_info_list>(
             ::dsn::rpc::call(
@@ -130,7 +130,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(
@@ -147,11 +147,11 @@ public:
 
     // ---------- call RPC_DEPLOY_SVC_DEPLOY_SVC_GET_SERVICE_INFO ------------
     // - synchronous 
-    std::pair<::dsn::error_code, deploy_info> get_service_info_sync(
+    std::pair< ::dsn::error_code, deploy_info> get_service_info_sync(
         const std::string& service_url, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<deploy_info>(
             ::dsn::rpc::call(
@@ -174,7 +174,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(
@@ -191,11 +191,11 @@ public:
 
     // ---------- call RPC_DEPLOY_SVC_DEPLOY_SVC_GET_CLUSTER_LIST ------------
     // - synchronous 
-    std::pair<::dsn::error_code, cluster_list> get_cluster_list_sync(
+    std::pair< ::dsn::error_code, cluster_list> get_cluster_list_sync(
         const std::string& format, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<cluster_list>(
             ::dsn::rpc::call(
@@ -218,7 +218,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(

--- a/src/dist/deployment_service/deploy_svc.server.h
+++ b/src/dist/deployment_service/deploy_svc.server.h
@@ -20,7 +20,7 @@ protected:
         reply(resp);
     }
     // RPC_DEPLOY_SVC_DEPLOY_SVC_UNDEPLOY 
-    virtual void on_undeploy(const std::string& service_url, ::dsn::rpc_replier<::dsn::error_code>& reply)
+    virtual void on_undeploy(const std::string& service_url, ::dsn::rpc_replier< ::dsn::error_code>& reply)
     {
         std::cout << "... exec RPC_DEPLOY_SVC_DEPLOY_SVC_UNDEPLOY ... (not implemented) " << std::endl;
         ::dsn::error_code resp;

--- a/src/dist/deployment_service/deploy_svc.server.impl.cpp
+++ b/src/dist/deployment_service/deploy_svc.server.impl.cpp
@@ -411,7 +411,7 @@ namespace dsn
         }
 
         void deploy_svc_service_impl::on_service_failure(
-            std::shared_ptr<::dsn::dist::deployment_unit> unit,
+            std::shared_ptr< ::dsn::dist::deployment_unit> unit,
             ::dsn::error_code err,
             const std::string& err_msg
             )
@@ -421,7 +421,7 @@ namespace dsn
         }
 
 
-        void deploy_svc_service_impl::download_service_resource_completed(error_code err, std::shared_ptr<::dsn::dist::deployment_unit> svc)
+        void deploy_svc_service_impl::download_service_resource_completed(error_code err, std::shared_ptr< ::dsn::dist::deployment_unit> svc)
         {
             if (err != ::dsn::ERR_OK)
             {
@@ -437,7 +437,7 @@ namespace dsn
         }
 
         void deploy_svc_service_impl::on_service_deployed(
-            std::shared_ptr<::dsn::dist::deployment_unit> unit,
+            std::shared_ptr< ::dsn::dist::deployment_unit> unit,
             ::dsn::error_code err,
             ::dsn::rpc_address addr
             )
@@ -502,7 +502,7 @@ namespace dsn
                     di.error = ::dsn::ERR_OK.to_string();
                     di.status = service_status::SS_PREPARE_RESOURCE;
                     _services.insert(
-                        std::unordered_map<std::string, std::shared_ptr<::dsn::dist::deployment_unit> >::value_type(
+                        std::unordered_map<std::string, std::shared_ptr< ::dsn::dist::deployment_unit> >::value_type(
                         req.name, svc
                         ));
                 }
@@ -770,7 +770,7 @@ namespace dsn
             reply(clist);
         }
 
-        std::shared_ptr<::dsn::dist::deployment_unit> deploy_svc_service_impl::get_service(const std::string& name)
+        std::shared_ptr< ::dsn::dist::deployment_unit> deploy_svc_service_impl::get_service(const std::string& name)
         {
             ::dsn::service::zauto_read_lock l(_service_lock);
             auto it = _services.find(name);

--- a/src/dist/deployment_service/deploy_svc.server.impl.h
+++ b/src/dist/deployment_service/deploy_svc.server.impl.h
@@ -34,12 +34,12 @@ namespace dsn
 
         private:
             mutable ::dsn::service::zrwlock_nr _service_lock;
-            std::unordered_map<std::string, std::shared_ptr<::dsn::dist::deployment_unit> > _services;
+            std::unordered_map<std::string, std::shared_ptr< ::dsn::dist::deployment_unit> > _services;
 
             struct cluster_ex
             {
                 cluster_info cluster;
-                std::unique_ptr<::dsn::dist::cluster_scheduler> scheduler;
+                std::unique_ptr< ::dsn::dist::cluster_scheduler> scheduler;
             };
 
             mutable ::dsn::service::zrwlock_nr _cluster_lock;
@@ -54,18 +54,18 @@ namespace dsn
             dsn_handle_t _cli_get_cluster_list;
 
         private:
-            void download_service_resource_completed(error_code err, std::shared_ptr<::dsn::dist::deployment_unit> svc);
-            std::shared_ptr<::dsn::dist::deployment_unit> get_service(const std::string& name);
+            void download_service_resource_completed(error_code err, std::shared_ptr< ::dsn::dist::deployment_unit> svc);
+            std::shared_ptr< ::dsn::dist::deployment_unit> get_service(const std::string& name);
             std::shared_ptr<cluster_ex> get_cluster(const std::string& name);
 
             void on_service_deployed(
-                std::shared_ptr<::dsn::dist::deployment_unit> unit,
+                std::shared_ptr< ::dsn::dist::deployment_unit> unit,
                 ::dsn::error_code err,
                 ::dsn::rpc_address addr
                 );
 
             void on_service_failure(
-                std::shared_ptr<::dsn::dist::deployment_unit> unit,
+                std::shared_ptr< ::dsn::dist::deployment_unit> unit,
                 ::dsn::error_code err,
                 const std::string& err_msg
                 );

--- a/src/dist/replication/client_ddl_tool/client_ddl.cpp
+++ b/src/dist/replication/client_ddl_tool/client_ddl.cpp
@@ -51,16 +51,28 @@ client_ddl::client_ddl(const std::vector<dsn::rpc_address>& meta_servers)
 dsn::error_code client_ddl::create_app(const std::string& app_name, const std::string& app_type, int partition_count, int replica_count)
 {
     if(partition_count < 1)
+    {
+        std::cout << "create app " << app_name << " failed: partition_count should >= 1" << std::endl;
         return ERR_INVALID_PARAMETERS;
+    }
 
     if(replica_count < 3)
+    {
+        std::cout << "create app " << app_name << " failed: replica_count should >= 3" << std::endl;
         return ERR_INVALID_PARAMETERS;
+    }
 
     if(app_name.empty() || !std::all_of(app_name.cbegin(),app_name.cend(),(bool (*)(int)) client_ddl::valid_app_char))
+    {
+        std::cout << "create app " << app_name << " failed: invalid app_name" << std::endl;
         return ERR_INVALID_PARAMETERS;
+    }
 
     if(app_type.empty() || !std::all_of(app_type.cbegin(),app_type.cend(),(bool (*)(int)) client_ddl::valid_app_char))
+    {
+        std::cout << "create app " << app_name << " failed: invalid app_type" << std::endl;
         return ERR_INVALID_PARAMETERS;
+    }
 
     std::shared_ptr<configuration_create_app_request> req(new configuration_create_app_request());
     req->app_name = app_name;
@@ -76,6 +88,7 @@ dsn::error_code client_ddl::create_app(const std::string& app_name, const std::s
     resp_task->wait();
     if (resp_task->error() != dsn::ERR_OK)
     {
+        std::cout << "create app " << app_name << " failed: [create] call server error: " << resp_task->error().to_string() << std::endl;
         return resp_task->error();
     }
 
@@ -83,14 +96,17 @@ dsn::error_code client_ddl::create_app(const std::string& app_name, const std::s
     ::unmarshall(resp_task->response(), resp);
     if(resp.err != dsn::ERR_OK)
     {
+        std::cout << "create app " << app_name << " failed: [create] received server error: " << resp.err.to_string() << std::endl;
         return resp.err;
     }
 
-    std::cout << "create app " << app_name << " succeed, waiting for app ready." << std::endl;
+    std::cout << "create app " << app_name << " succeed, waiting for app ready" << std::endl;
 
     int sleep_sec = 2;
     while(true)
     {
+        std::this_thread::sleep_for(std::chrono::seconds(sleep_sec));
+
         std::shared_ptr<configuration_query_by_index_request> query_req(new configuration_query_by_index_request());
         query_req->app_name = app_name;
 
@@ -99,34 +115,41 @@ dsn::error_code client_ddl::create_app(const std::string& app_name, const std::s
                     query_req
                     );
         query_task->wait();
+        if (query_task->error() == ERR_INVALID_STATE)
+        {
+            std::cout << app_name << " not ready yet, still waiting..." << std::endl;
+            continue;
+        }
+
         if (query_task->error() != dsn::ERR_OK)
         {
-            return dsn::ERR_IO_PENDING;
+            std::cout << "create app " << app_name << " failed: [query] call server error: " << query_task->error().to_string() << std::endl;
+            return query_task->error();
         }
 
         dsn::replication::configuration_query_by_index_response query_resp;
         ::unmarshall(query_task->response(), query_resp);
         if(query_resp.err != dsn::ERR_OK)
         {
-            return resp.err;
+            std::cout << "create app " << app_name << " failed: [query] received server error: " << query_resp.err.to_string() << std::endl;
+            return query_resp.err;
         }
         dassert(partition_count == query_resp.partition_count, "partition count not equal");
         int ready_count = 0;
-        for(int i =0; i < partition_count; i++)
+        for(int i = 0; i < partition_count; i++)
         {
-            partition_configuration pc = query_resp.partitions[i];
+            const partition_configuration& pc = query_resp.partitions[i];
             if (!pc.primary.is_invalid() && (pc.secondaries.size() >= replica_count / 2))
             {
                 ready_count++;
             }
         }
+        std::cout << app_name << " not ready yet, still waiting... ("
+                  << ready_count << "/" << partition_count << ")" << std::endl;
         if(ready_count == partition_count)
         {
             break;
         }
-        std::cout << app_name << " not ready yet, still waiting... ("
-                  << ready_count << "/" << partition_count << ")" << std::endl;
-        std::this_thread::sleep_for(std::chrono::seconds(sleep_sec));
     }
     std::cout << app_name << " is ready now!" << std::endl;
     return dsn::ERR_OK;
@@ -300,15 +323,15 @@ dsn::error_code client_ddl::list_app(const std::string& app_name, bool detailed,
     }
     std::ostream out(buf);
 
-    out << "app name:" << app_name << std::endl
-        << "app id:" << resp.app_id << std::endl
-        << "app partition count:" << resp.partition_count << std::endl;
+    out << "app_name: " << app_name << std::endl
+        << "app_id: " << resp.app_id << std::endl
+        << "partition_count: " << resp.partition_count << std::endl;
     if(detailed)
     {
         out << "details:" << std::endl
             << std::setw(10) << std::left << "pidx"
             << std::setw(10) << std::left << "ballot"
-            << std::setw(15) << std::left << "commmitdecree"
+            << std::setw(20) << std::left << "max_replica_count"
             << std::setw(25) << std::left << "primary"
             << std::setw(40) << std::left << "secondaries"
             << std::endl;
@@ -317,7 +340,7 @@ dsn::error_code client_ddl::list_app(const std::string& app_name, bool detailed,
             const dsn::replication::partition_configuration& p = resp.partitions[i];
             out << std::setw(10) << std::left << p.gpid.pidx
                 << std::setw(10) << std::left << p.ballot
-                << std::setw(15) << std::left << p.last_committed_decree
+                << std::setw(20) << std::left << p.max_replica_count
                 << std::setw(25) << std::left << p.primary.to_std_string()
                 << std::left<< p.secondaries.size() << ":[";
             for(int j = 0; j < p.secondaries.size(); j++)

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -925,7 +925,8 @@ void replica_stub::on_gc()
         std::vector<std::string> tmp_list;
         if (!dsn::utils::filesystem::get_subdirectories(dir, tmp_list, false))
         {
-            dassert(false, "Fail to get subdirectories in %s.", dir.c_str());
+            dwarn("on_gc(): failed to get subdirectories in %s", dir.c_str());
+            return;
         }
         sub_list.insert(sub_list.end(), tmp_list.begin(), tmp_list.end());
     }
@@ -940,14 +941,15 @@ void replica_stub::on_gc()
             time_t mt;
             if (!dsn::utils::filesystem::last_write_time(fpath, mt))
             {
-                dassert(false, "Fail to get last write time of %s.", fpath.c_str());
+                dwarn("on_gc(): failed to get last write time of %s", fpath.c_str());
+                continue;
             }
 
             if (mt > ::time(0) + _options.gc_disk_error_replica_interval_seconds)
             {
                 if (!dsn::utils::filesystem::remove_path(fpath))
                 {
-                    dassert(false, "Fail to delete directory %s.", fpath.c_str());
+                    dwarn("on_gc(): failed to delete directory %s", fpath.c_str());
                 }
             }
         }

--- a/src/dist/replication/meta_server/server_state.cpp
+++ b/src/dist/replication/meta_server/server_state.cpp
@@ -1066,13 +1066,14 @@ void server_state::create_app(dsn_message_t msg)
     int32_t index;
     ::unmarshall(msg ,request);
     
-    ddebug("create app request, name(%s), type(%s), partition_count(%d)",
+    ddebug("create app request, name(%s), type(%s), partition_count(%d), replica_count(%d)",
            request.app_name.c_str(),
            request.options.app_type.c_str(),
-           request.options.partition_count);
+           request.options.partition_count,
+           request.options.replica_count);
 
     auto option_match_check = [](const create_app_options& opt, const app_state& exist_app) {
-        return opt.partition_count==exist_app.partition_count && 
+        return opt.partition_count==exist_app.partition_count &&
                opt.app_type==exist_app.app_type;
     };
 

--- a/src/dist/replication/test/simple_kv/simple_kv.client.h
+++ b/src/dist/replication/test/simple_kv/simple_kv.client.h
@@ -49,7 +49,7 @@ public:
     }
     // ---------- call RPC_SIMPLE_KV_SIMPLE_KV_READ ------------
     // - synchronous 
-    std::pair<::dsn::error_code, std::string> read_sync(
+    std::pair< ::dsn::error_code, std::string> read_sync(
         const std::string& key, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         ::dsn::replication::read_semantic read_semantic = ::dsn::replication::read_semantic::ReadLastUpdate
@@ -92,7 +92,7 @@ public:
     }    
     // ---------- call RPC_SIMPLE_KV_SIMPLE_KV_WRITE ------------
     // - synchronous 
-    std::pair<::dsn::error_code, int32_t> write_sync(
+    std::pair< ::dsn::error_code, int32_t> write_sync(
         const kv_pair& pr, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0) 
         )
@@ -131,7 +131,7 @@ public:
     }    
     // ---------- call RPC_SIMPLE_KV_SIMPLE_KV_APPEND ------------
     // - synchronous 
-    std::pair<::dsn::error_code, int32_t> append_sync(
+    std::pair< ::dsn::error_code, int32_t> append_sync(
         const kv_pair& pr, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0) 
         )

--- a/src/tools/cli/cli.client.h
+++ b/src/tools/cli/cli.client.h
@@ -50,11 +50,11 @@ public:
 
     // ---------- call RPC_CLI_CLI_CALL ------------
     // - synchronous 
-    std::pair<::dsn::error_code, std::string> call_sync(
+    std::pair< ::dsn::error_code, std::string> call_sync(
         const command& c, 
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0), 
         int hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none)
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none)
     {
         return ::dsn::rpc::wait_and_unwrap<std::string>(
             ::dsn::rpc::call(
@@ -77,7 +77,7 @@ public:
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
         int reply_hash = 0,
         int request_hash = 0,
-        dsn::optional<::dsn::rpc_address> server_addr = dsn::none
+        dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
     {
         return ::dsn::rpc::call(


### PR DESCRIPTION
including:
- format "<::" to "< ::", and add check in format.sh
- remove assert in on_gc() to avoid coredump when file operation failed
- improve client_dll to print table creating process
