### PR TITLE
(1) fix network race of sending_message_queue (should be cleared only…

### DIFF
--- a/include/dsn/internal/network.h
+++ b/include/dsn/internal/network.h
@@ -210,7 +210,7 @@ namespace dsn {
     public:
         bool on_recv_reply(uint64_t key, message_ex* reply, int delay_ms);
         // return true if the socket should be closed
-        bool on_disconnected();
+        bool on_disconnected(bool is_write);
                
         virtual void connect() = 0;
         
@@ -241,7 +241,7 @@ namespace dsn {
     private:
         // return whether there are messages for sending; should always be called in lock
         bool unlink_message_for_send();
-        void clear(bool resend_msgs);
+        void clear_send_queue(bool resend_msgs);
 
     protected:
         // constant info

--- a/include/dsn/internal/task.h
+++ b/include/dsn/internal/task.h
@@ -83,6 +83,7 @@ struct __tls_dsn__
     nfs_node      *nfs;
     timer_service *tsvc;
 
+    int           last_worker_queue_size;
     uint64_t      node_pool_thread_ids; // 8,8,16 bits
     uint32_t      last_lower32_task_id; // 32bits
 

--- a/include/dsn/internal/task_spec.h
+++ b/include/dsn/internal/task_spec.h
@@ -156,7 +156,6 @@ class message_ex;
 class admission_controller;
 typedef void (*task_rejection_handler)(task*, admission_controller*);
 struct rpc_handler_info;
-typedef std::shared_ptr<rpc_handler_info> rpc_handler_ptr;
 
 typedef struct __io_mode_modifier__
 {

--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -134,6 +134,8 @@ namespace dsn
                     break;
 
                 msg->remove();
+
+                _message_count.fetch_sub(1, std::memory_order_relaxed);
             }
                         
             auto rmsg = CONTAINING_RECORD(msg, message_ex, dl);            

--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -49,9 +49,13 @@ namespace dsn
 {
     rpc_session::~rpc_session()
     {
-        utils::auto_lock<utils::ex_lock_nr> l(_lock);
-        dassert(0 == _sending_msgs.size(), "sending queue is not cleared yet");
-        dassert(0 == _message_count.load(), "sending queue is not cleared yet");
+        clear_send_queue(false);
+
+        {
+            utils::auto_lock<utils::ex_lock_nr> l(_lock);
+            dassert(0 == _sending_msgs.size(), "sending queue is not cleared yet");
+            dassert(0 == _message_count.load(), "sending queue is not cleared yet");
+        }
     }
 
     bool rpc_session::try_connecting()

--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -49,7 +49,9 @@ namespace dsn
 {
     rpc_session::~rpc_session()
     {
-        clear(false);
+        utils::auto_lock<utils::ex_lock_nr> l(_lock);
+        dassert(0 == _sending_msgs.size(), "sending queue is not cleared yet");
+        dassert(0 == _message_count.load(), "sending queue is not cleared yet");
     }
 
     bool rpc_session::try_connecting()
@@ -82,7 +84,7 @@ namespace dsn
         _connect_state = SS_DISCONNECTED;
     }
 
-    void rpc_session::clear(bool resend_msgs)
+    void rpc_session::clear_send_queue(bool resend_msgs)
     {
         //
         // - in concurrent case, resending _sending_msgs and _messages
@@ -336,41 +338,13 @@ namespace dsn
         _matcher = is_client ? _net.engine()->matcher() : nullptr;
     }
 
-    bool rpc_session::on_disconnected()
+    bool rpc_session::on_disconnected(bool is_write)
     {
         if (is_client())
         {
-            /* TODO(qinzuoyan): now that we will always call on_recv_reply() to notice the failure,
-             * there is no need to reconnect, which may cause problem when using the same socket.
-             *
-            // still connecting, let's retry
-            if (is_connecting() && ++_reconnect_count_after_last_success < 3)
-            {
-                set_disconnected();
-                connect();
-                return false;
-            }
-            */
-
             set_disconnected();
             rpc_session_ptr sp = this;
             _net.on_client_session_disconnected(sp);
-
-            // reconnect with new socket
-            //
-            // TODO(qinzuoyan): because '_reconnect_count_after_last_success' is a session scoped value,
-            // depending on it may cause endless resending, so we may always clear without resending:
-            //   clear(false);
-            //
-            // @imzhenyu: if we use clear(false), when there is a failure on established-connection, 
-            // the pending messages will be lost, this is considered harmful. the case for endless reconnecting
-            // is only possible when we can always *successfully* connect while fail on send, this should be
-            // very rare. so here we still use the old way but keep this mark here for future fix.
-            //
-            // @qinzuoyan: now that we will always call on_recv_reply() to notice the failure,
-            // there is no need to reconnect.
-            //clear(++_reconnect_count_after_last_success < 3);
-            clear(false);
         }
         
         else
@@ -378,6 +352,12 @@ namespace dsn
             rpc_session_ptr sp = this;
             _net.on_server_session_disconnected(sp);
         }
+
+        if (is_write)
+        {
+            clear_send_queue(false);
+        }
+
         return true;
     }
 

--- a/src/core/core/rpc_engine.h
+++ b/src/core/core/rpc_engine.h
@@ -105,8 +105,8 @@ private:
 class rpc_server_dispatcher
 {
 public:
-    bool  register_rpc_handler(rpc_handler_ptr& handler);
-    rpc_handler_ptr unregister_rpc_handler(dsn_task_code_t rpc_code);
+    bool  register_rpc_handler(rpc_handler_info* handler);
+    rpc_handler_info* unregister_rpc_handler(dsn_task_code_t rpc_code);
     rpc_request_task* on_request(message_ex* msg, service_node* node);
     int handler_count() const 
     {
@@ -115,7 +115,7 @@ public:
     }
 
 private:
-    typedef std::unordered_map<std::string, rpc_handler_ptr> rpc_handlers;
+    typedef std::unordered_map<std::string, rpc_handler_info*> rpc_handlers;
     rpc_handlers                  _handlers;
     mutable utils::rw_lock_nr     _handlers_lock;
 };
@@ -136,8 +136,8 @@ public:
     //
     // rpc registrations
     //
-    bool  register_rpc_handler(rpc_handler_ptr& handler, uint64_t vnid);
-    rpc_handler_ptr unregister_rpc_handler(dsn_task_code_t rpc_code, uint64_t vnid);
+    bool  register_rpc_handler(rpc_handler_info* handler, uint64_t vnid);
+    rpc_handler_info* unregister_rpc_handler(dsn_task_code_t rpc_code, uint64_t vnid);
 
     //
     // rpc routines

--- a/src/core/core/service_engine.cpp
+++ b/src/core/core/service_engine.cpp
@@ -62,7 +62,7 @@ service_node::service_node(service_app_spec& app_spec)
     _app_context_ptr = nullptr;
 }
 
-bool service_node::rpc_register_handler(rpc_handler_ptr& handler, uint64_t vnid)
+bool service_node::rpc_register_handler(rpc_handler_info* handler, uint64_t vnid)
 {
     for (auto& io : _ios)
     {
@@ -76,9 +76,9 @@ bool service_node::rpc_register_handler(rpc_handler_ptr& handler, uint64_t vnid)
     return true;
 }
 
-rpc_handler_ptr service_node::rpc_unregister_handler(dsn_task_code_t rpc_code, uint64_t vnid)
+rpc_handler_info* service_node::rpc_unregister_handler(dsn_task_code_t rpc_code, uint64_t vnid)
 {
-    rpc_handler_ptr ret = nullptr;
+    rpc_handler_info* ret = nullptr;
     for (auto& io : _ios)
     {
         if (io.rpc)
@@ -440,7 +440,7 @@ void service_engine::register_system_rpc_handler(
     int port /*= -1*/
     ) // -1 for all node
 {
-    ::dsn::rpc_handler_ptr h(new ::dsn::rpc_handler_info(code));
+    ::dsn::rpc_handler_info* h(new ::dsn::rpc_handler_info(code));
     h->name = std::string(name);
     h->c_handler = cb;
     h->parameter = param;

--- a/src/core/core/service_engine.cpp
+++ b/src/core/core/service_engine.cpp
@@ -444,6 +444,7 @@ void service_engine::register_system_rpc_handler(
     h->name = std::string(name);
     h->c_handler = cb;
     h->parameter = param;
+    h->add_ref();
 
     if (port == -1)
     {
@@ -452,7 +453,10 @@ void service_engine::register_system_rpc_handler(
             for (auto& io : n.second->ios())
             {
                 if (io.rpc)
+                {
+                    h->add_ref();
                     io.rpc->register_rpc_handler(h, 0);
+                }   
             }
         }
     }
@@ -464,7 +468,10 @@ void service_engine::register_system_rpc_handler(
             for (auto& io : it->second->ios())
             {
                 if (io.rpc)
+                {
+                    h->add_ref();
                     io.rpc->register_rpc_handler(h, 0);
+                }   
             }
         }
         else
@@ -472,6 +479,9 @@ void service_engine::register_system_rpc_handler(
             dwarn("cannot find service node with port %d", port);
         }
     }
+
+    if (1 == h->release_ref())
+        delete h;
 }
 
 service_node* service_engine::start_node(service_app_spec& app_spec)

--- a/src/core/core/service_engine.h
+++ b/src/core/core/service_engine.h
@@ -104,8 +104,8 @@ public:
     const service_app_spec& spec() const { return _app_spec;  }
     void* get_app_context_ptr() const { return _app_context_ptr; }
 
-    bool  rpc_register_handler(rpc_handler_ptr& handler, uint64_t vnid);
-    rpc_handler_ptr rpc_unregister_handler(dsn_task_code_t rpc_code, uint64_t vnid);
+    bool  rpc_register_handler(rpc_handler_info* handler, uint64_t vnid);
+    rpc_handler_info* rpc_unregister_handler(dsn_task_code_t rpc_code, uint64_t vnid);
 
 private:
     void*            _app_context_ptr; // app start returns this value and used by app stop

--- a/src/core/core/task.cpp
+++ b/src/core/core/task.cpp
@@ -88,6 +88,7 @@ __thread uint16_t tls_dsn_lower32_task_id_mask = 0;
                 );
         }
 
+        tls_dsn.last_worker_queue_size = -1;
         tls_dsn.node = node;
         tls_dsn.worker = worker;
         tls_dsn.worker_index = worker ? worker->index() : -1;

--- a/src/core/core/task.cpp
+++ b/src/core/core/task.cpp
@@ -471,7 +471,10 @@ timer_task::timer_task(
     _interval_milliseconds(interval_milliseconds),
     _cb(cb)
 {
-    dassert (TASK_TYPE_COMPUTE == spec().type, "this must be a computation type task, please use DEFINE_TASK_CODE to define the task code");
+    dassert (TASK_TYPE_COMPUTE == spec().type,
+        "%s is not a computation type task, please use DEFINE_TASK_CODE to define the task code",
+        spec().name.c_str()
+        );
 
     // enable timer randomization to avoid lots of timers execution simultaneously
     set_delay(dsn_random32(0, interval_milliseconds));
@@ -495,10 +498,12 @@ rpc_request_task::rpc_request_task(message_ex* request, rpc_handler_info* h, ser
         [](void*) { dassert(false, "rpc request task cannot be cancelled"); },
         request->header->client.hash, node),
     _request(request),
-    _handler(std::move(h))
+    _handler(h)
 {
     dbg_dassert (TASK_TYPE_RPC_REQUEST == spec().type, 
-        "task type must be RPC_REQUEST, please use DEFINE_TASK_CODE_RPC to define the task code");
+        "%s is not a RPC_REQUEST task, please use DEFINE_TASK_CODE_RPC to define the task code",
+        spec().name.c_str()
+        );
 
     _request->add_ref(); // released in dctor
 }
@@ -531,7 +536,9 @@ rpc_response_task::rpc_response_task(
     set_error_code(ERR_IO_PENDING);
 
     dbg_dassert (TASK_TYPE_RPC_RESPONSE == spec().type, 
-        "task must be of RPC_RESPONSE type, please use DEFINE_TASK_CODE_RPC to define the request task code");
+        "%s is not of RPC_RESPONSE type, please use DEFINE_TASK_CODE_RPC to define the request task code",
+        spec().name.c_str()
+        );
 
     _request = request;
     _response = nullptr;
@@ -590,7 +597,10 @@ aio_task::aio_task(
     _cb = cb;
     _is_null = (_cb == nullptr);
 
-    dassert (TASK_TYPE_AIO == spec().type, "task must be of AIO type, please use DEFINE_TASK_CODE_AIO to define the task code");
+    dassert (TASK_TYPE_AIO == spec().type, 
+        "%s is not of AIO type, please use DEFINE_TASK_CODE_AIO to define the task code",
+        spec().name.c_str()
+        );
     set_error_code(ERR_IO_PENDING);
 
     auto disk = task::get_current_disk();

--- a/src/core/tools/common/asio_rpc_session.cpp
+++ b/src/core/tools/common/asio_rpc_session.cpp
@@ -134,7 +134,7 @@ namespace dsn {
                 if (!!ec)
                 {
                     derror("asio write to %s failed: %s", _remote_addr.to_string(), ec.message().c_str());
-                    on_failure();
+                    on_failure(true);
                 }
                 else
                 {
@@ -160,9 +160,9 @@ namespace dsn {
             if (!is_client) start_read_next();
         }
         
-        void asio_rpc_session::on_failure()
+        void asio_rpc_session::on_failure(bool is_write)
         {
-            if (on_disconnected())
+            if (on_disconnected(is_write))
             {
                 try {
                     _socket->shutdown(boost::asio::socket_base::shutdown_type::shutdown_both);

--- a/src/core/tools/common/asio_rpc_session.cpp
+++ b/src/core/tools/common/asio_rpc_session.cpp
@@ -206,7 +206,7 @@ namespace dsn {
                             _remote_addr.to_string(),
                             ec.message().c_str()
                             );
-                        on_failure();
+                        on_failure(true);
                     }
                     release_ref();
                 });

--- a/src/core/tools/common/asio_rpc_session.h
+++ b/src/core/tools/common/asio_rpc_session.h
@@ -66,7 +66,7 @@ namespace dsn {
         private:
             virtual void do_read(int sz) override;
             void write(uint64_t signature);
-            void on_failure();
+            void on_failure(bool is_write = false);
             void set_options();  
             void on_message_read(message_ex* msg)
             {

--- a/src/core/tools/common/tracer.cpp
+++ b/src/core/tools/common/tracer.cpp
@@ -47,10 +47,11 @@ namespace dsn {
 
         static void tracer_on_task_enqueue(task* caller, task* callee)
         {
-            ddebug("%s ENQUEUE, task_id = %016llx, delay = %d ms",
+            ddebug("%s ENQUEUE, task_id = %016llx, delay = %d ms, queue size = %d",
                 callee->spec().name.c_str(),
                 callee->id(),
-                callee->delay_milliseconds()
+                callee->delay_milliseconds(),
+                tls_dsn.last_worker_queue_size
                 );
         }
 
@@ -129,17 +130,20 @@ namespace dsn {
         // return true means continue, otherwise early terminate with task::set_error_code
         static void tracer_on_aio_call(task* caller, aio_task* callee)
         {
-            ddebug("%s AIO.CALL, task_id = %016llx",
+            ddebug("%s AIO.CALL, task_id = %016llx, offset = %" PRIu64 ", size = %d",
                 callee->spec().name.c_str(),
-                callee->id()
+                callee->id(),
+                callee->aio()->file_offset,
+                callee->aio()->buffer_size
                 );
         }
 
         static void tracer_on_aio_enqueue(aio_task* this_)
         {
-            ddebug("%s AIO.ENQUEUE, task_id = %016llx",
+            ddebug("%s AIO.ENQUEUE, task_id = %016llx, queue size = %d",
                 this_->spec().name.c_str(),
-                this_->id()
+                this_->id(),
+                tls_dsn.last_worker_queue_size
                 );
         }
 
@@ -160,13 +164,14 @@ namespace dsn {
 
         static void tracer_on_rpc_request_enqueue(rpc_request_task* callee)
         {
-            ddebug("%s RPC.REQUEST.ENQUEUE (0x%p), task_id = %016llx, %s => %s, rpc_id = %016llx",
+            ddebug("%s RPC.REQUEST.ENQUEUE (0x%p), task_id = %016llx, %s => %s, rpc_id = %016llx, queue size = %d",
                 callee->spec().name.c_str(),
                 callee,
                 callee->id(),
                 callee->get_request()->from_address.to_string(),
                 callee->get_request()->to_address.to_string(),
-                callee->get_request()->header->rpc_id
+                callee->get_request()->header->rpc_id,
+                tls_dsn.last_worker_queue_size
                 );
         }
 
@@ -186,12 +191,13 @@ namespace dsn {
 
         static void tracer_on_rpc_response_enqueue(rpc_response_task* resp)
         {
-            ddebug("%s RPC.RESPONSE.ENQUEUE, task_id = %016llx, %s => %s, rpc_id = %016llx",
+            ddebug("%s RPC.RESPONSE.ENQUEUE, task_id = %016llx, %s => %s, rpc_id = %016llx, queue size = %d",
                 resp->spec().name.c_str(),
                 resp->id(),
                 resp->get_request()->to_address.to_string(),
                 resp->get_request()->from_address.to_string(),
-                resp->get_request()->header->rpc_id
+                resp->get_request()->header->rpc_id,
+                tls_dsn.last_worker_queue_size
                 );
         }
 

--- a/src/core/tools/hpc/hpc_network_provider.bsd.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.bsd.cpp
@@ -337,7 +337,7 @@ namespace dsn
                     if (err != EAGAIN && err != EWOULDBLOCK)
                     {
                         derror("(s = %d) sendmsg failed, err = %s", _socket, strerror(err));
-                        on_failure();                        
+                        on_failure(true);                        
                     }
                     else
                     {
@@ -548,13 +548,13 @@ namespace dsn
             }
         }
 
-        void hpc_rpc_session::on_failure()
+        void hpc_rpc_session::on_failure(bool is_write)
         {
             if (_socket != -1)
             {
                 _looper->unbind_io_handle((dsn_handle_t)(intptr_t)_socket, &_ready_event);
             }
-            if (on_disconnected())
+            if (on_disconnected(is_write))
                 close();            
         }
 

--- a/src/core/tools/hpc/hpc_network_provider.bsd.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.bsd.cpp
@@ -544,7 +544,7 @@ namespace dsn
                 }
 
                 derror("(s = %d) connect failed (in epoll), err = %s", _socket, strerror(err));
-                on_failure();
+                on_failure(true);
             }
         }
 
@@ -582,7 +582,7 @@ namespace dsn
             if (rt == -1 && err != EINPROGRESS)
             {
                 dwarn("(s = %d) connect failed, err = %s", _socket, strerror(err));
-                on_failure();
+                on_failure(true);
                 return;
             }
 

--- a/src/core/tools/hpc/hpc_network_provider.h
+++ b/src/core/tools/hpc/hpc_network_provider.h
@@ -131,7 +131,7 @@ namespace dsn {
         private:            
             void do_write(uint64_t signature);
             void close();
-            void on_failure();
+            void on_failure(bool is_write = false);
             void on_read_completed(message_ex* msg)
             {
                 if (msg->header->context.u.is_request)

--- a/src/core/tools/hpc/hpc_network_provider.linux.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.linux.cpp
@@ -327,7 +327,7 @@ namespace dsn
                     if (err != EAGAIN && err != EWOULDBLOCK)
                     {
                         derror("(s = %d) sendmsg failed, err = %s", _socket, strerror(err));
-                        on_failure();                        
+                        on_failure(true);
                     }
                     else
                     {
@@ -544,10 +544,10 @@ namespace dsn
             }
         }
 
-        void hpc_rpc_session::on_failure()
+        void hpc_rpc_session::on_failure(bool is_write)
         {
             _looper->unbind_io_handle((dsn_handle_t)(intptr_t)_socket, &_ready_event);
-            if (on_disconnected())
+            if (on_disconnected(is_write))
                 close();            
         }
 

--- a/src/core/tools/hpc/hpc_network_provider.linux.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.linux.cpp
@@ -540,7 +540,7 @@ namespace dsn
                 }
 
                 derror("(s = %d) connect failed (in epoll), err = %s", _socket, strerror(err));
-                on_failure();
+                on_failure(true);
             }
         }
 
@@ -575,7 +575,7 @@ namespace dsn
             if (rt == -1 && err != EINPROGRESS)
             {
                 dwarn("(s = %d) connect failed, err = %s", _socket, strerror(err));
-                on_failure();
+                on_failure(true);
                 return;
             }
 

--- a/src/core/tools/hpc/hpc_network_provider.win.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.win.cpp
@@ -523,7 +523,7 @@ namespace dsn
                 if (err != ERROR_SUCCESS)
                 {
                     dwarn("ConnectEx failed, err = %d", err);
-                    this->on_failure();
+                    this->on_failure(true);
                 }
                 else
                 {
@@ -560,7 +560,7 @@ namespace dsn
                 dwarn("ConnectEx failed, err = %d", ::WSAGetLastError());
                 this->release_ref();
 
-                on_failure();
+                on_failure(true);
             }
         }
 

--- a/src/core/tools/hpc/hpc_network_provider.win.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.win.cpp
@@ -406,7 +406,7 @@ namespace dsn
                 if (err != ERROR_SUCCESS)
                 {
                     dwarn("WSASend failed, err = %d", err);
-                    on_failure();
+                    on_failure(true);
                 }
                 else
                 {
@@ -477,7 +477,7 @@ namespace dsn
             {
                 dwarn("WSASend failed, err = %d", ::WSAGetLastError());
                 release_ref();
-                on_failure();
+                on_failure(true);
             }
             
             //dinfo("WSASend called, err = %d", rt);
@@ -506,9 +506,9 @@ namespace dsn
             _sending_buffer_start_index = 0;
         }
         
-        void hpc_rpc_session::on_failure()
+        void hpc_rpc_session::on_failure(bool is_write)
         {
-            if (on_disconnected())
+            if (on_disconnected(is_write))
                 close();
         }
 

--- a/src/dist/replication/client_lib/replication_common.cpp
+++ b/src/dist/replication/client_lib/replication_common.cpp
@@ -74,7 +74,7 @@ replication_options::replication_options()
 
     log_private_disabled = false;
     log_private_file_size_mb = 32;
-    log_private_batch_buffer_kb = 4;
+    log_private_batch_buffer_kb = 512;
     log_private_force_flush = true;
 
     log_shared_file_size_mb = 32;

--- a/src/dist/replication/lib/replication_app_base.cpp
+++ b/src/dist/replication/lib/replication_app_base.cpp
@@ -264,21 +264,36 @@ error_code replication_app_base::update_init_info(replica* r, int64_t shared_log
 
 void replication_app_base::dispatch_rpc_call(dsn_task_code_t code, binary_reader& reader, dsn_message_t response)
 {
-    auto it = _handlers.find(code);
-    if (it != _handlers.end())
+    local_rpc_handler_info* h = nullptr;
+    {
+        utils::auto_read_lock l(_handlers_lock);
+        auto it = _handlers.find(code);
+        if (it != _handlers.end())
+        {
+            h = it->second;
+            h->ref_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    
+    if (h)
     {
         if (response)
         {
             // replication layer error
             ::marshall(response, ERR_OK);
         }
-        it->second.first(this, it->second.second, reader, response);
+
+        h->callback(this, h->inner_callback, reader, response);
+        if (1 == h->ref_count.fetch_sub(1, std::memory_order_release))
+        {
+            delete h;
+        }
     }
     else
     {
-        dassert(false, "cannot find handler for rpc code %s in %s",
-                dsn_task_code_to_string(code), data_dir().c_str());
-    }
+        dwarn("cannot find handler for rpc code %s in %s",
+            dsn_task_code_to_string(code), data_dir().c_str());
+    }    
 }
 
 }} // end namespace

--- a/src/dist/replication/lib/replication_app_base.cpp
+++ b/src/dist/replication/lib/replication_app_base.cpp
@@ -220,11 +220,11 @@ error_code replication_app_base::write_internal(mutation_ptr& mu)
             binary_reader reader(update.data);
             dsn_message_t resp = (req ? dsn_msg_create_response(req) : nullptr);
 
-            uint64_t now = dsn_now_ns();
+            //uint64_t now = dsn_now_ns();
             dispatch_rpc_call(update.code, reader, resp);
-            now = dsn_now_ns() - now;
+            //now = dsn_now_ns() - now;
 
-            _app_commit_latency.set(now);
+            //_app_commit_latency.set(now);
         }
         else
         {
@@ -272,7 +272,7 @@ void replication_app_base::dispatch_rpc_call(dsn_task_code_t code, binary_reader
             // replication layer error
             ::marshall(response, ERR_OK);
         }
-        it->second(reader, response);
+        it->second.first(this, it->second.second, reader, response);
     }
     else
     {


### PR DESCRIPTION
… when write is completed, otherwise the buffer for sending is not hold by the msgs in sending queue)

(2) refine app replication base internal handler map for better performance
(3) print task queue length in logs on each enqueue
