### PR TITLE
move from_address into rpc message header so that when forwarded, the…

### DIFF
--- a/include/dsn/internal/rpc_message.h
+++ b/include/dsn/internal/rpc_message.h
@@ -65,12 +65,12 @@ namespace dsn
         char           rpc_name[DSN_MAX_TASK_CODE_NAME_LENGTH];
         uint64_t       vnid; // virtual node id
         dsn_msg_context_t context;
+        rpc_address       from_address;   // always ipv4/v6 address
 
         struct
         {
             int32_t  timeout_ms;
             int32_t  hash;
-            uint16_t port;                        
         } client;
 
         struct
@@ -89,10 +89,9 @@ namespace dsn
                                         // header not included for *recieved* 
 
         // by rpc and network
-        rpc_session_ptr        io_session;     // send/recv session
-        ::dsn::rpc_address     from_address;   // always ipv4/v6 address
-        ::dsn::rpc_address     to_address;     // always ipv4/v6 address
-        ::dsn::rpc_address     server_address; // used by requests, and may be of uri/group address
+        rpc_session_ptr        io_session;     // send/recv session        
+        rpc_address            to_address;     // always ipv4/v6 address
+        rpc_address            server_address; // used by requests, and may be of uri/group address
         uint16_t               local_rpc_code;
 
         // by message queuing
@@ -107,7 +106,8 @@ namespace dsn
         //
         bool is_right_header() const;
         bool is_right_body(bool is_write_msg) const;
-        error_code error() const { return header->server.error; }        
+        error_code error() const { return header->server.error; }    
+        rpc_address from_addr() const { return header->from_address; }
         static uint64_t new_id() { return ++_id; }
         static bool is_right_header(char* hdr);
         static int  get_body_length(char* hdr)

--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -372,7 +372,6 @@ namespace dsn
         //dinfo("%s: rpc_id = %016llx, code = %s", __FUNCTION__, reply->header->rpc_id, reply->header->rpc_name);
         if (reply != nullptr)
         {
-            reply->from_address = remote_address();
             reply->to_address = _net.address();
         }
 
@@ -383,9 +382,6 @@ namespace dsn
     {
         dbg_dassert(!is_client(), "only rpc server session can recv rpc requests");
 
-        //dinfo("%s: rpc_id = %016llx, code = %s", __FUNCTION__, msg->header->rpc_id, msg->header->rpc_name);
-        msg->from_address = remote_address();
-        msg->from_address.c_addr_ptr()->u.v4.port = msg->header->client.port;
         msg->to_address = _net.address();
 
         msg->io_session = this;
@@ -489,7 +485,7 @@ namespace dsn
         rpc_session_ptr s = msg->io_session.get();
         if (nullptr == s)
         {
-            rpc_address peer_addr = is_send ? msg->to_address : msg->from_address;
+            rpc_address peer_addr = is_send ? msg->to_address : msg->header->from_address;
             if (is_client)
             {
                 utils::auto_read_lock l(_clients_lock);

--- a/src/core/core/rpc_message.cpp
+++ b/src/core/core/rpc_message.cpp
@@ -106,7 +106,7 @@ DSN_API void dsn_msg_release_ref(dsn_message_t msg)
 
 DSN_API dsn_address_t dsn_msg_from_address(dsn_message_t msg)
 {
-    return ((::dsn::message_ex*)msg)->from_address.c_addr();
+    return ((::dsn::message_ex*)msg)->header->from_address.c_addr();
 }
 
 DSN_API dsn_address_t dsn_msg_to_address(dsn_message_t msg)
@@ -336,7 +336,6 @@ message_ex* message_ex::create_receive_message(const blob& data)
 message_ex* message_ex::copy()
 {
     message_ex* msg = new message_ex();
-    msg->from_address = from_address;
     msg->to_address = to_address;
     msg->local_rpc_code = local_rpc_code;
     msg->buffers = buffers;
@@ -423,8 +422,8 @@ message_ex* message_ex::create_response()
     hdr.context.u.is_request = false;
 
     msg->local_rpc_code = task_spec::get(local_rpc_code)->rpc_paired_code;
-    msg->from_address = to_address;
-    msg->to_address = from_address;
+    msg->header->from_address = to_address;
+    msg->to_address = header->from_address;
     msg->io_session = io_session;
 
     // join point 

--- a/src/core/tests/rpc_message.cpp
+++ b/src/core/tests/rpc_message.cpp
@@ -68,7 +68,7 @@ TEST(core, message_ex)
         ASSERT_EQ(ctx0.context, h.context.context);
         ASSERT_EQ(100, h.client.timeout_ms);
         ASSERT_EQ(1, h.client.hash);
-        ASSERT_EQ(0, h.client.port);
+        ASSERT_EQ(0, h.from_address.port());
 
         ASSERT_EQ(1u, m->buffers.size());
         ASSERT_EQ((int)RPC_CODE_FOR_TEST, m->local_rpc_code);
@@ -85,7 +85,7 @@ TEST(core, message_ex)
 
     { // create_response
         message_ex* request = message_ex::create_request(RPC_CODE_FOR_TEST, 0, 0);
-        request->from_address = rpc_address("127.0.0.1", 8080);
+        request->header->from_address = rpc_address("127.0.0.1", 8080);
         request->to_address = rpc_address("127.0.0.1", 9090);
         request->header->rpc_id = 123456;
 
@@ -105,8 +105,8 @@ TEST(core, message_ex)
 
         ASSERT_EQ(1u, response->buffers.size());
         ASSERT_EQ((int)RPC_CODE_FOR_TEST_ACK, response->local_rpc_code);
-        ASSERT_EQ(request->from_address, response->to_address);
-        ASSERT_EQ(request->to_address, response->from_address);
+        ASSERT_EQ(request->header->from_address, response->to_address);
+        ASSERT_EQ(request->to_address, response->header->from_address);
 
         ASSERT_TRUE(response->is_right_header());
         ASSERT_TRUE(response->is_right_body(true));
@@ -208,7 +208,7 @@ TEST(core, message_ex)
 
         dsn_msg_set_options(request, &opts, DSN_MSGM_CONTEXT | DSN_MSGM_VNID);
         message_ex* m = (message_ex*)request;
-        m->from_address = rpc_address("127.0.0.1", 8080);
+        m->header->from_address = rpc_address("127.0.0.1", 8080);
         m->to_address = rpc_address("127.0.0.1", 9090);
 
         dsn_msg_get_options(request, &opts);

--- a/src/core/tools/common/asio_net_provider.cpp
+++ b/src/core/tools/common/asio_net_provider.cpp
@@ -181,7 +181,6 @@ namespace dsn {
                             derror("invalid udp packet");
                         }
                     
-                        message->from_address.assign_ipv4(send_endpoint->address().to_v4().to_ulong(), send_endpoint->port());
                         message->to_address = address();
 
                         if (!_is_client)

--- a/src/core/tools/common/network.sim.cpp
+++ b/src/core/tools/common/network.sim.cpp
@@ -77,7 +77,6 @@ namespace dsn { namespace tools {
 
         blob bb(buffer, 0, msg->header->body_length + sizeof(message_header));
         message_ex* recv_msg = message_ex::create_receive_message(bb);
-        recv_msg->from_address = msg->from_address;
         recv_msg->to_address = msg->to_address;
         return recv_msg;
     }
@@ -111,7 +110,7 @@ namespace dsn { namespace tools {
                     node_scoper ns(rnet->node());
 
                     server_session->on_recv_request(recv_msg,
-                        recv_msg->to_address == recv_msg->from_address ?
+                        recv_msg->to_address == recv_msg->header->from_address ?
                         0 : rnet->net_delay_milliseconds()
                         );
                 }
@@ -142,7 +141,7 @@ namespace dsn { namespace tools {
                 node_scoper ns(_client->net().node());
 
                 _client->on_recv_reply(recv_msg->header->id, recv_msg,
-                    recv_msg->to_address == recv_msg->from_address ?
+                    recv_msg->to_address == recv_msg->header->from_address ?
                     0 : (static_cast<sim_network_provider*>(&_net))->net_delay_milliseconds()
                     );
             }

--- a/src/core/tools/common/tracer.cpp
+++ b/src/core/tools/common/tracer.cpp
@@ -72,7 +72,7 @@ namespace dsn {
                 ddebug("%s EXEC BEGIN, task_id = %016llx, %s => %s, rpc_id = %016llx",
                     this_->spec().name.c_str(),
                     this_->id(),
-                    tsk->get_request()->from_address.to_string(),
+                    tsk->get_request()->from_addr().to_string(),
                     tsk->get_request()->to_address.to_string(),
                     tsk->get_request()->header->rpc_id
                     );
@@ -85,7 +85,7 @@ namespace dsn {
                     this_->spec().name.c_str(),
                     this_->id(),
                     tsk->get_request()->to_address.to_string(),
-                    tsk->get_request()->from_address.to_string(),
+                    tsk->get_request()->from_addr().to_string(),
                     tsk->get_request()->header->rpc_id
                     );
             }
@@ -154,7 +154,7 @@ namespace dsn {
             ddebug(
                 "%s RPC.CALL: %s => %s, rpc_id = %016llx, callback_task = %016llx, timeout = %d ms",
                 hdr.rpc_name,
-                req->from_address.to_string(),
+                req->from_addr().to_string(),
                 req->to_address.to_string(),
                 hdr.rpc_id,
                 callee ? callee->id() : 0,
@@ -168,7 +168,7 @@ namespace dsn {
                 callee->spec().name.c_str(),
                 callee,
                 callee->id(),
-                callee->get_request()->from_address.to_string(),
+                callee->get_request()->from_addr().to_string(),
                 callee->get_request()->to_address.to_string(),
                 callee->get_request()->header->rpc_id,
                 tls_dsn.last_worker_queue_size
@@ -183,7 +183,7 @@ namespace dsn {
             ddebug(
                 "%s RPC.REPLY: %s => %s, rpc_id = %016llx",
                 hdr.rpc_name,
-                msg->from_address.to_string(),
+                msg->from_addr().to_string(),
                 msg->to_address.to_string(),
                 hdr.rpc_id
                 );
@@ -195,7 +195,7 @@ namespace dsn {
                 resp->spec().name.c_str(),
                 resp->id(),
                 resp->get_request()->to_address.to_string(),
-                resp->get_request()->from_address.to_string(),
+                resp->get_request()->from_addr().to_string(),
                 resp->get_request()->header->rpc_id,
                 tls_dsn.last_worker_queue_size
                 );

--- a/src/dist/replication/test/simple_kv/case.cpp
+++ b/src/dist/replication/test/simple_kv/case.cpp
@@ -583,7 +583,7 @@ void event_on_rpc::init(message_ex* msg, task* tsk)
         sprintf(buf, "%016lx", msg->header->rpc_id);
         _rpc_id = buf;
         _rpc_name = msg->header->rpc_name;
-        _from = address_to_node(msg->from_address);
+        _from = address_to_node(msg->from_addr());
         _to = address_to_node(msg->to_address);
     }
 }


### PR DESCRIPTION
… initiation site is remembered. 
