### PR TITLE
refine performance improvement using throttling and inline

### DIFF
--- a/include/dsn/internal/exp_delay.h
+++ b/include/dsn/internal/exp_delay.h
@@ -36,7 +36,8 @@
 # pragma once
 
 # include <dsn/internal/singleton.h>
-# include <list>
+# include <vector>
+# include <cassert>
 
 namespace dsn
 {
@@ -53,7 +54,7 @@ namespace dsn
             _threshold = 0x0fffffff;
         }
 
-        void initialize(const std::list<int>& delays, int threshold)
+        void initialize(const std::vector<int>& delays, int threshold)
         {
             assert((int)delays.size() == DELAY_COUNT);
             
@@ -108,7 +109,7 @@ namespace dsn
             memcpy((void*)_delay, (const void*)s_default_delay, sizeof(_delay));
         }
 
-        void initialize(const std::list<int>& delays)
+        void initialize(const std::vector<int>& delays)
         {
             assert((int)delays.size() == DELAY_COUNT);
 

--- a/include/dsn/internal/task.h
+++ b/include/dsn/internal/task.h
@@ -292,12 +292,18 @@ public:
 
     virtual void  exec() override
     {
-        _handler->run(_request);
+        if (0 == _enqueue_ts_ns
+            || dsn_now_ns() - _enqueue_ts_ns < 
+            (uint64_t)_request->header->client.timeout_ms * 1000000ULL)
+        {
+            _handler->run(_request);
+        }
     }
 
 protected:
     message_ex      *_request;
     rpc_handler_info* _handler;
+    uint64_t         _enqueue_ts_ns;
 };
 
 class rpc_response_task : public task, public transient_object

--- a/include/dsn/internal/task.h
+++ b/include/dsn/internal/task.h
@@ -132,7 +132,6 @@ public:
     error_code              error() const { return _error; }
     service_node*           node() const { return _node; }
     bool                    is_empty() const { return _is_null; }
-    uint64_t                enqueue_ts_ns() { return _recv_ts_ns; }
 
     // static helper utilities
     static task*            get_current_task();
@@ -179,7 +178,6 @@ private:
     service_node           *_node;
     trackable_task         _context_tracker; // when tracker is gone, the task is cancelled automatically
     dsn_task_cancelled_handler_t _on_cancel;
-    uint64_t               _recv_ts_ns;
 
 public:
     // used by task queue only

--- a/include/dsn/internal/task_spec.h
+++ b/include/dsn/internal/task_spec.h
@@ -45,6 +45,7 @@
 # include <dsn/internal/join_point.h>
 # include <dsn/internal/extensible_object.h>
 # include <dsn/internal/configuration.h>
+# include <dsn/internal/exp_delay.h>
 
 ENUM_BEGIN(dsn_log_level_t, LOG_LEVEL_INVALID)
     ENUM_REG(LOG_LEVEL_INFORMATION)
@@ -135,6 +136,20 @@ ENUM_BEGIN(grpc_mode_t, GRPC_TARGET_INVALID)
     ENUM_REG(GRPC_TO_ANY)
 ENUM_END(grpc_mode_t)
 
+typedef enum throttling_mode_t
+{
+    TM_NONE,    // no throttling applied
+    TM_REJECT,  // reject the incoming request 
+    TM_DELAY,   // delay network receive ops to reducing incoming rate
+    TM_INVALID
+} throttling_mode_t;
+
+ENUM_BEGIN(throttling_mode_t, TM_INVALID)
+    ENUM_REG(TM_NONE)
+    ENUM_REG(TM_REJECT)
+    ENUM_REG(TM_DELAY)
+ENUM_END(throttling_mode_t)
+
 // define network header format for RPC
 DEFINE_CUSTOMIZED_ID_TYPE(network_header_format);
 DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_DSN);
@@ -176,22 +191,25 @@ public:
     dsn_task_type_t        type;
     std::string            name;    
     dsn_task_code_t        rpc_paired_code;
+    shared_exp_delay       rpc_request_delayer;
     // ]
 
     // configurable [
     dsn_task_priority_t    priority;
     grpc_mode_t            grpc_mode; // used when a rpc request is sent to a group address
     dsn_threadpool_code_t  pool_code;
-    bool                   allow_inline; // allow task executed in other thread pools or tasks    
-    bool                   fast_execution_in_network_thread;
+
+    // allow task executed in other thread pools or tasks    
+    // for TASK_TYPE_COMPUTE - allow-inline allows a task being executed in its caller site
+    // for other tasks - allow-inline allows a task being execution in io-thread
+    bool                   allow_inline;
     bool                   randomize_timer_delay_if_zero; // to avoid many timers executing at the same time
     network_header_format  rpc_call_header_format;
     rpc_channel            rpc_call_channel;
     int32_t                rpc_timeout_milliseconds;
     int32_t                rpc_request_resend_timeout_milliseconds; // 0 for no auto-resend
-    bool                   rpc_request_dropped_on_long_queue; // 
-    bool                   rpc_request_dropped_on_timeout_with_high_possibility; // default is false
-    double                 rpc_request_queue_wait_time_approximation_weight;
+    throttling_mode_t      rpc_request_throttling_mode; // 
+    std::vector<int>       rpc_request_delays_milliseconds; // see exp_delay for delaying recving
     // ]
 
     task_rejection_handler rejection_handler;
@@ -235,16 +253,18 @@ CONFIG_BEGIN(task_spec)
     CONFIG_FLD_ENUM(dsn_task_priority_t, priority, TASK_PRIORITY_COMMON, TASK_PRIORITY_INVALID, true, "task priority")
     CONFIG_FLD_ENUM(grpc_mode_t, grpc_mode, GRPC_TO_LEADER, GRPC_TARGET_INVALID, false, "group rpc mode: GRPC_TO_LEADER, GRPC_TO_ALL, GRPC_TO_ANY")
     CONFIG_FLD_ID(threadpool_code2, pool_code, THREAD_POOL_DEFAULT, true, "thread pool to execute the task")
-    CONFIG_FLD(bool, bool, allow_inline, false, "whether the task can be executed inlined with the caller task")    
-    CONFIG_FLD(bool, bool, fast_execution_in_network_thread, false, "whether the rpc task can be executed in network threads directly")
+    CONFIG_FLD(bool, bool, allow_inline, false, 
+        "allow task executed in other thread pools or tasks "
+        "for TASK_TYPE_COMPUTE - allow-inline allows a task being executed in its caller site "
+        "for other tasks - allow-inline allows a task being execution in io-thread "        
+        )
     CONFIG_FLD(bool, bool, randomize_timer_delay_if_zero, false, "whether to randomize the timer delay to random(0, timer_interval), if the initial delay is zero, to avoid multiple timers executing at the same time (e.g., checkpointing)")
     CONFIG_FLD_ID(network_header_format, rpc_call_header_format, NET_HDR_DSN, false, "what kind of header format for this kind of rpc calls")
     CONFIG_FLD_ID(rpc_channel, rpc_call_channel, RPC_CHANNEL_TCP, false, "what kind of network channel for this kind of rpc calls")
     CONFIG_FLD(int32_t, uint64, rpc_timeout_milliseconds, 5000, "what is the default timeout (ms) for this kind of rpc calls")    
     CONFIG_FLD(int32_t, uint64, rpc_request_resend_timeout_milliseconds, 0, "for how long (ms) the request will be resent if no response is received yet, 0 for disable this feature")
-    CONFIG_FLD(bool, bool, rpc_request_dropped_on_long_queue, false, "throttling: whether the request requests can be dropped on queue length > pool.queue_length_throttling_threshold")
-    CONFIG_FLD(bool, bool, rpc_request_dropped_on_timeout_with_high_possibility, false, "throttling: whether to drop a rpc request when it will be timeout with high possibility")
-    CONFIG_FLD(double, double, rpc_request_queue_wait_time_approximation_weight, 1.0, "throttling: wait(N) = weight*wait(N-1) + (1-weight)*wait(N-2)")
+    CONFIG_FLD_ENUM(throttling_mode_t, rpc_request_throttling_mode, TM_NONE, TM_INVALID, false, "throttling mode for rpc requets: TM_NONE, TM_REJECT, TM_DELAY when queue length > pool.queue_length_throttling_threshold")
+    CONFIG_FLD_INT_LIST(rpc_request_delays_milliseconds, "how many milliseconds to delay recving rpc session for when queue length ~= [1.0, 1.2, 1.4, 1.6, 1.8, >=2.0] x pool.queue_length_throttling_threshold, e.g., 0, 0, 1, 2, 5, 10")
 CONFIG_END
 
 struct threadpool_spec

--- a/include/dsn/internal/task_spec.h
+++ b/include/dsn/internal/task_spec.h
@@ -210,6 +210,7 @@ public:
     int32_t                rpc_request_resend_timeout_milliseconds; // 0 for no auto-resend
     throttling_mode_t      rpc_request_throttling_mode; // 
     std::vector<int>       rpc_request_delays_milliseconds; // see exp_delay for delaying recving
+    bool                   rpc_request_dropped_before_execution_when_timeout;
     // ]
 
     task_rejection_handler rejection_handler;
@@ -265,6 +266,7 @@ CONFIG_BEGIN(task_spec)
     CONFIG_FLD(int32_t, uint64, rpc_request_resend_timeout_milliseconds, 0, "for how long (ms) the request will be resent if no response is received yet, 0 for disable this feature")
     CONFIG_FLD_ENUM(throttling_mode_t, rpc_request_throttling_mode, TM_NONE, TM_INVALID, false, "throttling mode for rpc requets: TM_NONE, TM_REJECT, TM_DELAY when queue length > pool.queue_length_throttling_threshold")
     CONFIG_FLD_INT_LIST(rpc_request_delays_milliseconds, "how many milliseconds to delay recving rpc session for when queue length ~= [1.0, 1.2, 1.4, 1.6, 1.8, >=2.0] x pool.queue_length_throttling_threshold, e.g., 0, 0, 1, 2, 5, 10")
+    CONFIG_FLD(bool, bool, rpc_request_dropped_before_execution_when_timeout, false, "whether to drop a request right before execution when its queueing time is already greater than its timeout value")    
 CONFIG_END
 
 struct threadpool_spec

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -212,7 +212,18 @@ namespace dsn {
             if (sp->on_rpc_response_enqueue.execute(call, true))
             {
                 call->set_delay(delay_ms);
-                call->enqueue(err, reply);
+
+                if (ERR_OK == err)
+                    call->enqueue(err, reply);
+                else
+                {
+                    call->enqueue(err, nullptr);
+
+                    // because (1) initially, the ref count is zero
+                    //         (2) upper apps may call add_ref already
+                    call->add_ref();
+                    call->release_ref();
+                }
             }
 
             // release the task when necessary

--- a/src/core/core/rpc_message.cpp
+++ b/src/core/core/rpc_message.cpp
@@ -378,7 +378,8 @@ message_ex* message_ex::copy_and_prepare_send()
         // the message_header is hidden ahead of the buffer, expose it to buffer
         dassert(buffers.size() == 1, "there must be only one buffer for read msg");
         dassert((char*)header + sizeof(message_header) == (char*)buffers[0].data(), "header and content must be contigous");
-        copy->buffers[0] = copy->buffers[0].range(-sizeof(message_header));
+
+        copy->buffers[0] = copy->buffers[0].range(-(int)sizeof(message_header));
 
         // switch the flag
         copy->_is_read = false;

--- a/src/core/core/task.cpp
+++ b/src/core/core/task.cpp
@@ -512,7 +512,8 @@ rpc_request_task::rpc_request_task(message_ex* request, rpc_handler_info* h, ser
         [](void*) { dassert(false, "rpc request task cannot be cancelled"); },
         request->header->client.hash, node),
     _request(request),
-    _handler(h)
+    _handler(h),
+    _enqueue_ts_ns(0)
 {
     dbg_dassert (TASK_TYPE_RPC_REQUEST == spec().type, 
         "%s is not a RPC_REQUEST task, please use DEFINE_TASK_CODE_RPC to define the task code",
@@ -529,6 +530,10 @@ rpc_request_task::~rpc_request_task()
 
 void rpc_request_task::enqueue()
 {
+    if (spec().rpc_request_dropped_before_execution_when_timeout)
+    {
+        _enqueue_ts_ns = dsn_now_ns();
+    }
     task::enqueue(node()->computation()->get_pool(spec().pool_code));
 }
 

--- a/src/core/perf.tests/rpc.cpp
+++ b/src/core/perf.tests/rpc.cpp
@@ -89,3 +89,88 @@ TEST(core, rpc_perf_test)
     }
 
 }
+
+TEST(core, rpc_perf_test_sync)
+{
+    ::dsn::rpc_address localhost("localhost", 20101);
+
+    std::chrono::steady_clock clock;
+    auto tic = clock.now();
+
+    int round = 1000000;
+    int concurrency = 10;
+    int total_query_count = round * concurrency;
+
+    std::vector<task_ptr> tasks;
+    for (int i = 0; i < round; i++)
+    {
+        for (int j = 0; j < concurrency; j++)
+        {
+            int req = 0;
+            auto task = ::dsn::rpc::call(
+                localhost,
+                RPC_TEST_HASH,
+                req,
+                nullptr,
+                [](error_code err, std::string&& result) 
+                {
+                    // nothing to do
+                }
+                );
+
+            tasks.push_back(task);
+        }
+
+        for (auto& t : tasks)
+            t->wait();
+
+        tasks.clear();
+    }
+
+    auto toc = clock.now();
+    auto time_us = std::chrono::duration_cast<std::chrono::microseconds>(toc - tic).count();
+    std::cout << "rpc-sync perf test: throughput = " 
+        << total_query_count * 1000000llu / time_us << " #/s, avg latency = "
+        << time_us / total_query_count 
+        << " us"<< std::endl;
+}
+
+TEST(core, lpc_perf_test_sync)
+{
+    std::chrono::steady_clock clock;
+    auto tic = clock.now();
+
+    int round = 1000000;
+    int concurrency = 10;
+    int total_query_count = round * concurrency;
+    std::vector<task_ptr> tasks;
+    std::vector<std::string> results;
+    for (int i = 0; i < round; i++)
+    {
+        results.resize(concurrency);
+        for (int j = 0; j < concurrency; j++)
+        {
+            auto task = ::dsn::tasking::enqueue(
+                LPC_TEST_HASH,
+                nullptr,
+                [&results, j]() {
+                    std::string r = dsn_get_current_app_data_dir();
+                    results[j] = std::move(r);
+                }
+                );
+            tasks.push_back(task);
+        }
+        
+        for (auto& t : tasks)
+            t->wait();
+
+        tasks.clear();
+    }
+
+    auto toc = clock.now();
+    auto time_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic).count();
+    std::cout << "lpc-sync perf test: throughput = "
+        << total_query_count * 1000000000llu / time_ns << " #/s, avg latency = "
+        << time_ns / total_query_count
+        << " ns" << std::endl;
+}

--- a/src/core/perf.tests/test_utils.h
+++ b/src/core/perf.tests/test_utils.h
@@ -49,6 +49,7 @@ using namespace ::dsn;
 
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_TEST_SERVER)
 DEFINE_TASK_CODE_RPC(RPC_TEST_HASH, TASK_PRIORITY_COMMON, THREAD_POOL_TEST_SERVER)
+DEFINE_TASK_CODE(LPC_TEST_HASH, TASK_PRIORITY_COMMON, THREAD_POOL_TEST_SERVER)
 DEFINE_TASK_CODE_RPC(RPC_TEST_STRING_COMMAND, TASK_PRIORITY_COMMON, THREAD_POOL_TEST_SERVER)
 
 extern int g_test_count;
@@ -72,8 +73,8 @@ public:
 
     void on_rpc_test(const int& test_id, ::dsn::rpc_replier<std::string>& replier)
     {
-        std::string r = ::dsn::task::get_current_worker()->name();
-        replier(r);
+        std::string r = dsn_get_current_app_data_dir();
+        replier(std::move(r));
     }
 
     void on_rpc_string_test(dsn_message_t message) {

--- a/src/core/tools/common/shared_io_service.h
+++ b/src/core/tools/common/shared_io_service.h
@@ -47,7 +47,7 @@ namespace dsn {
 
         // TODO: seperate this into per-node service, so we can use
         // task::get_current_node for faster access to the nodes in all tasks
-        // coz tasks may run in io-threads when [task.xxx] fast_execution_in_network_thread is true
+        // coz tasks may run in io-threads when [task.xxx] allow_inline is true
         class shared_io_service : public utils::singleton<shared_io_service>
         {
         public:

--- a/src/core/tools/hpc/fastrun.cpp
+++ b/src/core/tools/hpc/fastrun.cpp
@@ -59,8 +59,7 @@ namespace dsn
                 spec.env_factory_name = ("dsn::tools::hpc_env_provider");
 
             if (spec.timer_factory_name == "")
-                spec.timer_factory_name = use_mixed_queue ? ("dsn::tools::io_looper_timer_service")
-                                                           : "dsn::tools::simple_timer_service";
+                spec.timer_factory_name = "dsn::tools::io_looper_timer_service";
 
             network_client_config cs;
             cs.factory_name = "dsn::tools::hpc_network_provider";


### PR DESCRIPTION
(1) merge allow_inline and fast_execution_in_network_thread so that allow_line is applicable to all tasks
(2) remove throttling by execution time estimation and rejection, since its runtime overhead is too high and there is risks where estimation is not precise which leads to lots of false positives;
(3) recover throttling mechanism by delaying receiving rpc session's recv ops. Now for edge services, we can use reject, and for internal services, we can use delay.
(4) always use io-looper-timer instead of simple-timer-service in fastrun.
(5)   restore rpc request drop before execution when its queueing time is already larger than its timeout
