### PR TITLE
avoid string map inquery when the binary versions of rpc client/serve…

### DIFF
--- a/include/dsn/internal/rpc_message.h
+++ b/include/dsn/internal/rpc_message.h
@@ -55,6 +55,12 @@ namespace dsn
         char          *buffer;
     } dsn_buffer_t;
 
+    struct fast_rpc_name
+    {
+        uint64_t local_rpc_id : 16;
+        uint64_t local_binary_hash : 48;
+    };
+
     typedef struct message_header
     {
         int32_t        hdr_crc32;
@@ -64,6 +70,7 @@ namespace dsn
         uint64_t       id;      // sequence id, can be used to track source
         uint64_t       rpc_id;  // correlation id for connecting rpc caller, request, and response tasks
         char           rpc_name[DSN_MAX_TASK_CODE_NAME_LENGTH];
+        fast_rpc_name  rpc_name_fast;
         uint64_t       vnid; // virtual node id
         dsn_msg_context_t context;
         rpc_address       from_address; // always ipv4/v6 address,
@@ -153,6 +160,9 @@ namespace dsn
         int                    _rw_offset;    // current buffer offset
         bool                   _rw_committed; // mark if it is in middle state of reading/writing
         bool                   _is_read;      // is for read(recv) or write(send)
+
+    public:
+        static uint64_t s_local_binary_hash;  // used by fast_rpc_name
     };
 
 } // end namespace

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -394,6 +394,16 @@ namespace dsn {
     }
 
     //----------------------------------------------------------------------------------------------
+    rpc_server_dispatcher::rpc_server_dispatcher()
+    {
+        _vhandlers.resize(dsn_task_code_max() + 1);
+        for (auto& h : _vhandlers)
+        {
+            h = new std::pair<rpc_handler_info*, utils::rw_lock_nr>();
+            h->first = nullptr;
+        }
+    }
+
     bool rpc_server_dispatcher::register_rpc_handler(rpc_handler_info* handler)
     {
         auto name = std::string(dsn_task_code_to_string(handler->code));
@@ -404,7 +414,12 @@ namespace dsn {
         if (it == _handlers.end() && it2 == _handlers.end())
         {
             _handlers[name] = handler;
-            _handlers[handler->name] = handler;            
+            _handlers[handler->name] = handler;   
+
+            {
+                utils::auto_write_lock l(_vhandlers[handler->code]->second);
+                _vhandlers[handler->code]->first = handler;
+            }
             return true;
         }
         else
@@ -427,6 +442,11 @@ namespace dsn {
             std::string name = it->second->name;
             _handlers.erase(it);
             _handlers.erase(name);
+
+            {
+                utils::auto_write_lock l(_vhandlers[rpc_code]->second);
+                _vhandlers[rpc_code]->first = nullptr;
+            }
         }
 
         ret->unregister();
@@ -436,6 +456,20 @@ namespace dsn {
     rpc_request_task* rpc_server_dispatcher::on_request(message_ex* msg, service_node* node)
     {
         rpc_handler_info* handler = nullptr;
+        if (msg->header->rpc_name_fast.local_binary_hash == message_ex::s_local_binary_hash)
+        {
+            msg->local_rpc_code = (uint16_t)msg->header->rpc_name_fast.local_rpc_id;
+
+            {
+                utils::auto_read_lock l(_vhandlers[msg->local_rpc_code]->second);
+                handler = _vhandlers[msg->local_rpc_code]->first;
+                if (nullptr != handler)
+                {
+                    handler->add_ref();
+                }
+            }
+        }
+        else
         {
             utils::auto_read_lock l(_handlers_lock);
             auto it = _handlers.find(msg->header->rpc_name);

--- a/src/core/core/rpc_engine.h
+++ b/src/core/core/rpc_engine.h
@@ -105,6 +105,7 @@ private:
 class rpc_server_dispatcher
 {
 public:
+    rpc_server_dispatcher();
     bool  register_rpc_handler(rpc_handler_info* handler);
     rpc_handler_info* unregister_rpc_handler(dsn_task_code_t rpc_code);
     rpc_request_task* on_request(message_ex* msg, service_node* node);
@@ -118,6 +119,8 @@ private:
     typedef std::unordered_map<std::string, rpc_handler_info*> rpc_handlers;
     rpc_handlers                  _handlers;
     mutable utils::rw_lock_nr     _handlers_lock;
+
+    std::vector<std::pair<rpc_handler_info*, utils::rw_lock_nr>*  > _vhandlers;
 };
 
 class rpc_engine

--- a/src/core/perf.tests/rpc.cpp
+++ b/src/core/perf.tests/rpc.cpp
@@ -97,7 +97,7 @@ TEST(core, rpc_perf_test_sync)
     std::chrono::steady_clock clock;
     auto tic = clock.now();
 
-    int round = 1000000;
+    int round = 100000;
     int concurrency = 10;
     int total_query_count = round * concurrency;
 


### PR DESCRIPTION
…r are the same, i.e., using interger instead to accelerate rpc handler inquery.
