### PR TITLE
improvement on counter query; fix bug in replica commit decree counter;

### DIFF
--- a/include/dsn/dist/replication/replication_app_base.h
+++ b/include/dsn/dist/replication/replication_app_base.h
@@ -209,6 +209,7 @@ public:
     const std::string& data_dir() const { return _dir_data; }
     const std::string& learn_dir() const { return _dir_learn; }
     bool is_delta_state_learning_supported() const { return _is_delta_state_learning_supported; }
+    void reset_counters_after_learning();
 
     //
     // set physical error (e.g., disk error) so that the app is dropped by replication later

--- a/src/dist/replication/lib/replica_chkpt.cpp
+++ b/src/dist/replication/lib/replica_chkpt.cpp
@@ -276,6 +276,7 @@ namespace dsn {
                     filename = utils::filesystem::path_combine(chk_dir, filename);
                 }
                 _app->apply_checkpoint(resp->state, CHKPT_COPY);
+                _app->reset_counters_after_learning();
             }
 
             _primary_states.checkpoint_task = nullptr;

--- a/src/dist/replication/lib/replica_learn.cpp
+++ b/src/dist/replication/lib/replica_learn.cpp
@@ -691,6 +691,8 @@ void replica::on_copy_remote_state_completed(
             err = _app->apply_checkpoint(lstate, CHKPT_LEARN);
             if (err == ERR_OK)
             {
+                _app->reset_counters_after_learning();
+
                 dassert(_app->last_committed_decree() >= _app->last_durable_decree(), "");
                 // because if the original _app->last_committed_decree > resp.last_committed_decree,
                 // the learn_start_decree will be set to 0, which makes learner to learn from scratch

--- a/src/dist/replication/lib/replication_app_base.cpp
+++ b/src/dist/replication/lib/replication_app_base.cpp
@@ -178,6 +178,11 @@ void replication_app_base::install_perf_counters()
     _app_req_throughput.init("eon.app", ss.str().c_str(), COUNTER_TYPE_RATE, "request throughput for current app");
 }
 
+void replication_app_base::reset_counters_after_learning()
+{
+    _app_commit_decree.set(_last_committed_decree.load());
+}
+
 error_code replication_app_base::open_internal(replica* r, bool create_new)
 {
     auto err = open(create_new);


### PR DESCRIPTION
Problem 1.
counter's index and name was not synced in the previous implementation of rDSN. Monitor
Solution 1. 
added name and index in the return value of "counter.value/valuei/sample/samplei". Now we can know whether the index is changed.

Problem 2.
In the test of killing a replica, we noticed that the decree number of respawn replica was too low. This was caused by lack of setting values after learning.
Solution 2.
added one function to set the counter value of learning. 
