### PR TITLE
improve dsn_ipv4_local()

### DIFF
--- a/src/core/core/address.cpp
+++ b/src/core/core/address.cpp
@@ -121,11 +121,13 @@ DSN_API uint32_t dsn_ipv4_from_host(const char* name)
     return (uint32_t)ntohl(addr.sin_addr.s_addr);
 }
 
+// if network_interface is "", then return the first non-loopback ipv4 address.
 DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
 {
     uint32_t ret = 0;
 
 # ifndef _WIN32
+    static const char loopback[4] = { 127, 0, 0, 1 };
     struct ifaddrs* ifa = nullptr;
     if (getifaddrs(&ifa) == 0)
     {
@@ -133,11 +135,14 @@ DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
         while (i != nullptr)
         {
             if (i->ifa_name != nullptr &&
-                strcmp(i->ifa_name, network_interface) == 0 &&
                 i->ifa_addr != nullptr && 
                 i->ifa_addr->sa_family == AF_INET
                 )
             {
+                if (strcmp(i->ifa_name, network_interface) == 0 ||
+                        (network_interface[0] == '\0'
+                         && strncmp((const char*)&((struct sockaddr_in *)i->ifa_addr)->sin_addr.s_addr, loopback, 4) != 0)
+                   )
                 ret = (uint32_t)ntohl(((struct sockaddr_in *)i->ifa_addr)->sin_addr.s_addr);
                 break;
             }

--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -457,7 +457,7 @@ namespace dsn
 
         static const char* inteface = dsn_config_get_value_string(
             "network", "primary_interface",
-            "eth0", "network interface name used to init primary ip address");
+            "", "network interface name used to init primary ipv4 address, if empty, means using the first non-loopback ipv4 address");
 
         uint32_t ip = 0;
 


### PR DESCRIPTION
to return the first non-loopback ipv4 address when network_interface is empty (which is also the default value).

In the older version, the network_interface's default value is "eth0", which may cause not-found problem when the proper ipv4 address is not using "eth0".
