### PR TITLE
make cmake more user-friendly

### DIFF
--- a/bin/dsn.ext.copy.cmd
+++ b/bin/dsn.ext.copy.cmd
@@ -29,14 +29,14 @@ GOTO copy_latest
                 SET ltime=%%i %%j
             )
         )
-    )
-    IF "%max_time%" EQU "" (
-        SET max_time=%ltime%
-        SET max_config=%lconfig%
-    ) ELSE (
-        IF "%max_time%" lss "%ltime%" (
+        IF "%max_time%" EQU "" (
             SET max_time=%ltime%
             SET max_config=%lconfig%
+        ) ELSE (
+            IF "%max_time%" lss "%ltime%" (
+                SET max_time=%ltime%
+                SET max_config=%lconfig%
+            )
         )
     )
     REM ECHO max_time=%max_time%
@@ -44,9 +44,13 @@ GOTO copy_latest
     GOTO:EOF
     
 :copy_latest
+
+IF "%max_config%" EQU "" (
+    ECHO "cannot find latest build"
+    GOTO exit
+)
+
 ECHO latest build is in dir %PROJ_LIB_DIR%\%max_config%
-    
-IF "%max_config%" EQU "" GOTO exit
 
 @ECHO ON
 XCOPY /F /Y /S %PROJ_LIB_DIR%\%max_config% %DST_LIB_DIR%


### PR DESCRIPTION
Without this commit, external project building failure would always result in an information of "File not found - MinSizeRel", no matter what build type is selected, which may perplex the user.
