### PR TITLE
bug fix

### DIFF
--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -116,6 +116,14 @@ extern DSN_API int         dsn_task_get_ref(dsn_task_t task);
 extern DSN_API bool        dsn_task_cancel(dsn_task_t task, bool wait_until_finished);
 
 /*!
+ set delay for a task
+
+ \param task                the task handle
+ \param delay_ms            the delay milliseconds for a task
+ */
+extern DSN_API void        dsn_task_set_delay(dsn_task_t task, int delay_ms);
+
+/*!
  cancel a task
 
  \param task                the task handle

--- a/include/dsn/cpp/task_helper.h
+++ b/include/dsn/cpp/task_helper.h
@@ -93,6 +93,11 @@ namespace dsn
             return dsn_task_cancel2(_task, wait_until_finished, finished);
         }
 
+        void set_delay(int delay_ms)
+        {
+            dsn_task_set_delay(_task, delay_ms);
+        }
+
         void wait() const
         {
             return dsn_task_wait(_task);

--- a/src/core/core/service_api_c.cpp
+++ b/src/core/core/service_api_c.cpp
@@ -404,6 +404,11 @@ DSN_API bool dsn_task_cancel(dsn_task_t task, bool wait_until_finished)
     return ((::dsn::task*)(task))->cancel(wait_until_finished);
 }
 
+DSN_API void dsn_task_set_delay(dsn_task_t task, int delay_ms)
+{
+    ((::dsn::task*)(task))->set_delay(delay_ms);
+}
+
 DSN_API bool dsn_task_cancel2(dsn_task_t task, bool wait_until_finished, bool* finished)
 {
     return ((::dsn::task*)(task))->cancel(wait_until_finished, finished);

--- a/src/dist/replication/lib/replica_config.cpp
+++ b/src/dist/replication/lib/replica_config.cpp
@@ -399,8 +399,7 @@ void replica::on_update_configuration_on_meta_server_reply(error_code err, dsn_m
         if (err != ERR_INVALID_VERSION)
         {
             rpc_address target(_stub->_failure_detector->get_servers());
-            _primary_states.reconfiguration_task = rpc::call(
-                target,
+            _primary_states.reconfiguration_task = rpc::create_rpc_response_task(
                 request,
                 this,
                 [this, req](error_code err, dsn_message_t request, dsn_message_t response)
@@ -408,9 +407,12 @@ void replica::on_update_configuration_on_meta_server_reply(error_code err, dsn_m
                     on_update_configuration_on_meta_server_reply(err, request, response, std::move(req));
                 },
                 gpid_to_hash(get_gpid())
-                );
+            );
+            //when the rpc call timeout, we would delay to do the recall
+            _primary_states.reconfiguration_task->set_delay(1000);
+            dsn_rpc_call(target.c_addr(), _primary_states.reconfiguration_task->native_handle());
             return;
-        }        
+        }
     }
 
     ddebug(

--- a/src/dist/replication/meta_server/greedy_load_balancer.cpp
+++ b/src/dist/replication/meta_server/greedy_load_balancer.cpp
@@ -505,7 +505,9 @@ void greedy_load_balancer::run()
         app_state& app = _state->_apps[i];
         if (app.status != AS_AVAILABLE)
         {
-            dinfo("ignore app(%s)", app.app_name.c_str());
+            if (app.status != AS_DROPPED)
+                is_system_healthy = false;
+            dinfo("ignore app(%s), status(%s)", app.app_name.c_str(), enum_to_string(app.status));
             continue;
         }
         for (int j = 0; j < app.partition_count; j++)
@@ -582,6 +584,9 @@ void greedy_load_balancer::on_config_changed(std::shared_ptr<configuration_updat
 void greedy_load_balancer::run(global_partition_id gpid)
 {
     zauto_read_lock l(_state->_lock);
+    if (_state->_apps[gpid.app_id - 1].status != AS_AVAILABLE)
+        return;
+
     partition_configuration& pc = _state->_apps[gpid.app_id-1].partitions[gpid.pidx];
     run_lb(pc);
 }

--- a/src/dist/replication/meta_server/server_state.cpp
+++ b/src/dist/replication/meta_server/server_state.cpp
@@ -1302,8 +1302,9 @@ void server_state::update_configuration(
             tasking::enqueue(
                 LPC_CM_UPDATE_CONFIGURATION,
                 nullptr,
-                [svc = this->_meta_svc, req_ptr = std::move(req)]() mutable {
-                    svc->update_configuration_on_machine_failure(req_ptr);
+                [this, cb = std::move(callback), req_ptr = std::move(req)]() mutable
+                {
+                    this->update_configuration(req_ptr, nullptr, cb);
                 },
                 0,
                 std::chrono::milliseconds(delay_ms));


### PR DESCRIPTION
1. add api dsn_task_set_delay in api_layer1
2. when a meta server is down, a replica server's update configuration may spin frequently. Fix this.
3. Fix meta server's bug in dropping table.
4. Fix bug when meta is removing a primary and the primary is updating configuration meanwhile
