### PR TITLE
fix two bugs about rpc session exposed by fault injection

### DIFF
--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -368,8 +368,9 @@ namespace dsn
     {
     }
 
-    bool rpc_session::on_disconnected(bool /*is_write*/)
+    bool rpc_session::on_disconnected(bool is_write)
     {
+        bool ret;
         if (set_disconnected())
         {
             rpc_session_ptr sp = this;
@@ -382,14 +383,19 @@ namespace dsn
                 _net.on_server_session_disconnected(sp);
             }
 
-            clear_send_queue(false);
-
-            return true;
+            ret = true;
         }
         else
         {
-            return false;
+            ret = false;
         }
+
+        if (is_write)
+        {
+            clear_send_queue(false);
+        }
+
+        return ret;
     }
 
     void rpc_session::on_recv_message(message_ex* msg, int delay_ms)

--- a/src/core/tools/common/asio_rpc_session.cpp
+++ b/src/core/tools/common/asio_rpc_session.cpp
@@ -170,18 +170,23 @@ namespace dsn {
         {
             if (on_disconnected(is_write))
             {
-                try {
-                    _socket->shutdown(boost::asio::socket_base::shutdown_type::shutdown_both);
-                    _socket->close();
-                }
-                catch (std::exception& /*ex*/)
-                {
-                    /*dwarn("network session %s exits failed, err = %s",
-                    remote_address().to_ip_string().c_str(),
-                    static_cast<int>remote_address().port(),
-                    ex.what()
-                    );*/
-                }
+                safe_close();
+            }
+        }
+
+        void asio_rpc_session::safe_close()
+        {
+            try {
+                _socket->shutdown(boost::asio::socket_base::shutdown_type::shutdown_both);
+                _socket->close();
+            }
+            catch (std::exception& /*ex*/)
+            {
+                /*dwarn("network session %s exits failed, err = %s",
+                remote_address().to_ip_string().c_str(),
+                static_cast<int>remote_address().port(),
+                ex.what()
+                );*/
             }
         }
 

--- a/src/core/tools/common/asio_rpc_session.h
+++ b/src/core/tools/common/asio_rpc_session.h
@@ -57,7 +57,7 @@ namespace dsn {
             virtual ~asio_rpc_session();
             virtual void send(uint64_t signature) override { return write(signature); }
             virtual void close_on_fault_injection() override {
-                _socket->close();
+                safe_close();
             }
 
         public:
@@ -72,6 +72,7 @@ namespace dsn {
             {
                 on_recv_message(msg, 0);
             }
+            void safe_close();
 
         private:
             std::shared_ptr<boost::asio::ip::tcp::socket> _socket;            


### PR DESCRIPTION
- ensure fault injection is safe for asio sockets
- fix failure handling for rpc sessions about _sending_buffer access
