### PR TITLE
fix improper core-only header file usage outside rDSN core and windows build break

### DIFF
--- a/include/dsn/dist/replication/replication.codes.h
+++ b/include/dsn/dist/replication/replication.codes.h
@@ -35,7 +35,7 @@
 
 #pragma once
 
-#include <dsn/internal/task_spec.h>
+#include <dsn/cpp/auto_codes.h>
 
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_META_SERVER)
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_META_STATE)

--- a/src/core/core/thrift_parser.cpp
+++ b/src/core/core/thrift_parser.cpp
@@ -144,11 +144,19 @@ int thrift_header_parser::prepare_buffers_on_send(message_ex* msg, unsigned int 
     buffers[0].sz = length + sizeof(int32_t)*2;
     //then the response error code string length
     ptr -= sizeof(int32_t);
+# ifdef _WIN32
+    *((int*)ptr) = htonl(length);
+# else
     *((int*)ptr) = htobe32(length);
+# endif
     //then the total length of all message: error_code_string's memory + msg_body
     ptr -= sizeof(int32_t);
     length = length + sizeof(int32_t) + msg->header->body_length;
+# ifdef _WIN32
+    *((int*)ptr) = htonl(length);
+# else
     *((int*)ptr) = htobe32(length);
+# endif
 
     // we ignore the message header when response thrift
     offset += sizeof(message_header);

--- a/src/dist/cluster_scheduler/scheduler_providers/machine_pool_mgr.cpp
+++ b/src/dist/cluster_scheduler/scheduler_providers/machine_pool_mgr.cpp
@@ -1,5 +1,4 @@
 #include "machine_pool_mgr.h"
-#include <dsn/internal/task.h>
 #include <fstream>
 
 #ifdef __TITLE__

--- a/src/dist/replication/test/meta_test/balancer_simulator/balancer_simulator.cpp
+++ b/src/dist/replication/test/meta_test/balancer_simulator/balancer_simulator.cpp
@@ -163,15 +163,9 @@ void greedy_balancer_perfect_move_primary()
     }
 }
 
-extern void dsn_core_init();
-void dsn_init()
-{
-    dsn_core_init();
-    dsn_run_config("config.ini", false);
-}
-
 int main(int, char**)
 {
-    dsn_init();
+    dsn_run_config("config.ini", false);
     greedy_balancer_perfect_move_primary();
+    return 0;
 }

--- a/src/dist/replication/test/meta_test/unit_test/data_definition_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/data_definition_test.cpp
@@ -2,7 +2,6 @@
 
 #include <dsn/service_api_c.h>
 #include <dsn/service_api_cpp.h>
-#include <dsn/internal/rpc_message.h>
 
 #include "meta_service.h"
 #include "server_state.h"
@@ -10,7 +9,9 @@
 
 dsn_message_t create_corresponding_receive(dsn_message_t request_msg)
 {
-    dsn::message_ex* rpc_message = reinterpret_cast<dsn::message_ex*>(request_msg);
+    return dsn_msg_copy(request_msg);
+
+    /*dsn::message_ex* rpc_message = reinterpret_cast<dsn::message_ex*>(request_msg);
     std::vector<dsn::blob>& buffers = rpc_message->buffers;
 
     int total_length = rpc_message->body_size() + sizeof(dsn::message_header);
@@ -25,7 +26,7 @@ dsn_message_t create_corresponding_receive(dsn_message_t request_msg)
     dassert(i==total_length, "");
 
     dsn::message_ex* result = dsn::message_ex::create_receive_message( dsn::blob(recv_buffer, total_length) );
-    return result;
+    return result;*/
 }
 
 class fake_receiver_meta_service: public dsn::replication::meta_service

--- a/src/dist/replication/zookeeper/zookeeper_session.cpp
+++ b/src/dist/replication/zookeeper/zookeeper_session.cpp
@@ -32,7 +32,6 @@
  *     2015-12-04, @shengofsun (sunweijie@xiaomi.com)
  */
 
-#include <dsn/internal/task.h>
 #include <zookeeper.h>
 
 #include "zookeeper_session.h"


### PR DESCRIPTION
- fix improper core-only header file usage outside rDSN core
- fix windows build break
