### PR TITLE
bug fix: unintialized variable in meta server

### DIFF
--- a/include/dsn/cpp/rpc_stream.h
+++ b/include/dsn/cpp/rpc_stream.h
@@ -71,7 +71,7 @@ namespace dsn
             void* ptr;
             size_t size;
             bool r = dsn_msg_read_next(msg, &ptr, &size);
-            dbg_dassert(r, "read msg must have one segment of buffer ready");
+            dassert(r, "read msg must have one segment of buffer ready");
 
             blob bb((const char*)ptr, 0, (int)size);
             init(bb);

--- a/include/dsn/ext/hpc-locks/benaphore.h
+++ b/include/dsn/ext/hpc-locks/benaphore.h
@@ -109,8 +109,10 @@ public:
 
     void unlock()
     {
+#ifndef NDEBUG
         auto tid = ::dsn::utils::get_current_tid();
         assert(tid == m_owner.load(std::memory_order_relaxed));
+#endif
         int recur = --m_recursion;
         if (recur == 0)
             m_owner.store(::dsn::utils::get_invalid_tid(), std::memory_order_relaxed);

--- a/src/dist/replication/meta_server/meta_service.cpp
+++ b/src/dist/replication/meta_server/meta_service.cpp
@@ -54,7 +54,8 @@ namespace dsn { namespace replication {
 meta_service::meta_service():
     serverlet("meta_service"),
     _failure_detector(nullptr),
-    _started(false)
+    _started(false),
+    _meta_ctrl_flags(0)
 {
     _node_live_percentage_threshold_for_update = 65;
     _opts.initialize();


### PR DESCRIPTION
- uninitialized variable control flag in meta service
- warnings in hpc locks
