### PR TITLE
fix web studio break due to serialization format definition change

### DIFF
--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -525,6 +525,7 @@ extern DSN_API void          dsn_msg_add_ref(dsn_message_t msg);
 /*! release reference to the message, paired with /ref dsn_msg_add_ref */
 extern DSN_API void          dsn_msg_release_ref(dsn_message_t msg);
 
+/*! define various serialization format supported by rDSN, note any changes here must also be reflected in src/tools/.../dsn_transport.js */
 typedef enum dsn_msg_serialize_format
 {
     DSF_INVALID = 0,
@@ -533,6 +534,7 @@ typedef enum dsn_msg_serialize_format
     DSF_THRIFT_JSON = 3,
     DSF_PROTOC_BINARY = 4,
     DSF_PROTOC_JSON = 5,
+    DSF_JSON = 6
 } dsn_msg_serialize_format;
 
 /*! explicitly create a received RPC request, MUST released mannually later using dsn_msg_release_ref */

--- a/src/tools/webstudio/app_package/static/js/dsn/dsn_transport.js
+++ b/src/tools/webstudio/app_package/static/js/dsn/dsn_transport.js
@@ -85,11 +85,12 @@ Thrift.DSNTransport.prototype = {
 
 var DSN = {
     payload_format : {
-        'DSF_THRIFT_BINARY' : 0,
-        'DSF_THRIFT_COMPACT' : 1,
-        'DSF_THRIFT_JSON' : 2,
-        'DSF_PROTOC_BINARY' : 3,
-        'DSF_PROTOC_JSON' : 4,
+        'DSF_THRIFT_BINARY' : 1,
+        'DSF_THRIFT_COMPACT' : 2,
+        'DSF_THRIFT_JSON' : 3,
+        'DSF_PROTOC_BINARY' : 4,
+        'DSF_PROTOC_JSON' : 5,
+        'DSF_JSON' : 6,
     },
     
     thrift_type : {


### PR DESCRIPTION
now the web studio comes back, and we add notes in core so that any changes are also applied in JavaScript counterpart. 
