### PR TITLE
fix bug #405 - state lost due to improper use of update_init_info

### DIFF
--- a/src/dist/replication/lib/replica_learn.cpp
+++ b/src/dist/replication/lib/replica_learn.cpp
@@ -512,7 +512,12 @@ void replica::on_learn_reply(
 
         if (err == ERR_OK)
         {
-            err = _app->open_internal(this, true);
+            err = _app->open_new_internal(
+                this,
+                _stub->_log->on_partition_reset(get_gpid(), 0),
+                _private_log->on_partition_reset(get_gpid(), 0)
+                );
+
             if (err != ERR_OK)
             {
                 derror(
@@ -530,20 +535,6 @@ void replica::on_learn_reply(
 
             // reset prepare list
             _prepare_list->reset(0);
-
-            err = _app->update_init_info(
-                this,
-                _stub->_log->on_partition_reset(get_gpid(), 0),
-                _private_log->on_partition_reset(get_gpid(), 0)
-                );
-            if (err != ERR_OK)
-            {
-                derror(
-                    "%s: on_learn_reply[%016llx]: learnee = %s, update app init info failed, err = %s",
-                    name(), req.signature, resp.config.primary.to_string(),
-                    err.to_string()
-                    );
-            }
         }
         
         if (err != ERR_OK)
@@ -567,6 +558,19 @@ void replica::on_learn_reply(
         dassert(resp.state.files.size() == 0, "");
         dassert(_potential_secondary_states.learning_status == learner_status::LearningWithoutPrepare, "");
         _potential_secondary_states.learning_status = learner_status::LearningWithPrepareTransient;
+
+        // reset log positions for later mutations
+        // WARNING: it still requires checkpoint operation in later 
+        // on_copy_remote_state_completed to ensure the state is completed
+        // if there is a failure in between, our checking
+        // during app::open_internal will invalidate the logs
+        // appended by the mutations AFTER current position
+        err = _app->update_init_info(
+            this,
+            _stub->_log->on_partition_reset(get_gpid(), _app->last_committed_decree()),
+            _private_log->on_partition_reset(get_gpid(), _app->last_committed_decree()),
+            _app->last_committed_decree()
+            );
 
         // reset preparelist
         _potential_secondary_states.learning_start_prepare_decree = resp.prepare_start_decree;
@@ -806,13 +810,6 @@ void replica::on_copy_remote_state_completed(
         if (err == ERR_OK)
         {
             dassert(_app->last_committed_decree() == _app->last_durable_decree(), "");
-
-            // update log positions after checkpoint
-            err = _app->update_init_info(
-                this,
-                _stub->_log->on_partition_reset(get_gpid(), 0),
-                _private_log->on_partition_reset(get_gpid(), 0)
-            );
         }
 
         if (err == ERR_NO_NEED_OPERATE)

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -254,9 +254,12 @@ void replica_stub::initialize(const replication_options& opts, bool clear/* = fa
         {
             it->second->close();
             std::string new_dir = it->second->dir() + ".err";
-            if (!utils::filesystem::rename_path(it->second->dir(), new_dir))
+            if (utils::filesystem::directory_exists(it->second->dir()))
             {
-                dassert(false, "we cannot recover from the above error, exit ...");
+                if (!utils::filesystem::rename_path(it->second->dir(), new_dir))
+                {
+                    dassert(false, "we cannot recover from the above error, exit ...");
+                }
             }
         }
         rps.clear();

--- a/src/dist/replication/lib/replication_app_base.h
+++ b/src/dist/replication/lib/replication_app_base.h
@@ -57,7 +57,7 @@ public:
     int32_t magic;
     int32_t crc;
     ballot  init_ballot;
-    decree  init_decree;
+    decree  init_durable_decree;
     int64_t init_offset_in_shared_log;
     int64_t init_offset_in_private_log;
 
@@ -169,7 +169,7 @@ public:
     //    
     ::dsn::replication::decree last_durable_decree() 
     {
-        return _callbacks.calls.get_last_checkpoint_decree(_app_context_callbacks);
+        return _app_context_callbacks ? _callbacks.calls.get_last_checkpoint_decree(_app_context_callbacks) : 0;
     }
 
 public:
@@ -188,11 +188,17 @@ private:
     friend class replica;
     friend class replica_stub;
     
-    ::dsn::error_code open_internal(replica* r, bool create_new);
+    ::dsn::error_code open_internal(replica* r);
+    ::dsn::error_code open_new_internal(replica* r, int64_t shared_log_start, int64_t private_log_start);
     ::dsn::error_code write_internal(mutation_ptr& mu);
 
     const replica_init_info& init_info() const { return _info; }
-    ::dsn::error_code update_init_info(replica* r, int64_t shared_log_offset, int64_t private_log_offset);
+    ::dsn::error_code update_init_info(
+        replica* r, 
+        int64_t shared_log_offset, 
+        int64_t private_log_offset, 
+        int64_t durable_decree
+        );
 
     void install_perf_counters();
 


### PR DESCRIPTION
The nightly test reveals that there are further bugs for the fixing of #405 

Problem:

When the learning process switches to `LeanringWithPrepareTransient` state, we need to do the checkpoint to ensure the later logs from mutations are contiguous with the previous state on disk. However, we cannot do that in replication thread. The previous approach delays this checkpoint to the non-replicated thread, which leads to possible state holes when there is a failure in between. 

Solution:

We still delay the checkpoint to later thread, but this time we pretend that the checkpoint is already done by adding the current commit decree in init-info of the app state. If there is a failure in-between this point and the checkpoint success later, we detect this hole during the opening of the app. When there is a failure, we report that the app fails (TODO: we can still reuse the state to save certain learning cost later). 
