### PR TITLE
fix bug of receving rpc request when task_engine is not started

### DIFF
--- a/src/core/core/rpc_engine.h
+++ b/src/core/core/rpc_engine.h
@@ -139,6 +139,7 @@ public:
         const service_app_spec& spec, 
         io_modifer& ctx
         );
+    void start_serving() { _is_serving = true; }
 
     //
     // rpc registrations
@@ -193,7 +194,8 @@ private:
 
     std::unique_ptr<uri_resolver_manager>            _uri_resolver_mgr;
     
-    volatile bool                 _is_running;
+    volatile bool                                    _is_running;
+    volatile bool                                    _is_serving;
 };
 
 // ------------------------ inline implementations --------------------

--- a/src/core/core/service_engine.cpp
+++ b/src/core/core/service_engine.cpp
@@ -372,7 +372,7 @@ error_code service_node::start()
         }
     }
 
-    // start io engines (only computation and timer), others are started in app start task
+    // start io engines (only timer, disk and rpc), others are started in app start task
     for (auto& io : _ios)
     {
         start_io_engine_in_main(io);
@@ -388,6 +388,14 @@ error_code service_node::start()
         ::dsn::tools::node_scoper scoper(this);
         _app_info.app.app_context_ptr = _app_spec.role->layer1.create(_app_spec.role->type_name, dsn_gpid{ 0 });
     }
+
+    // start rpc serving
+    for (auto& io : _ios)
+    {
+        if (io.rpc)
+            io.rpc->start_serving();
+    }
+
     return err;
 }
 


### PR DESCRIPTION
the case is:
- rpc_engine is started by start_io_engine_in_main()
- received rpc request from network, and call generate_l2_rpc_request_task()
- if request is RPC_L2_CLIENT_READ or RPC_L2_CLIENT_WRITE, then the request is processed
- if the task_engine is not started now, will assert in task_worker_pool::enqueue()

another fix way is check _computation->is_started():

```
rpc_request_task* service_node::generate_l2_rpc_request_task(message_ex* req)
{
    if (!_computation->is_started())
        return nullptr;
    ... ...
```

but I think it is not a general fix comparing with my commit.
