### PR TITLE
fix layer2 rpc call retry 

### DIFF
--- a/include/dsn/internal/rpc_message.h
+++ b/include/dsn/internal/rpc_message.h
@@ -131,7 +131,7 @@ namespace dsn
         struct
         {
             uint64_t hash; // for both partition hash and thread hash for the exact location of this request
-            int32_t  timeout_ms; // timeout in milliseconds
+            int32_t  timeout_ms;
             int32_t  padding;
         } client;
 

--- a/src/dist/common_providers/partition_resolver_simple.cpp
+++ b/src/dist/common_providers/partition_resolver_simple.cpp
@@ -94,9 +94,9 @@ namespace dsn
         void partition_resolver_simple::on_access_failure(int partition_index, error_code err)
         {
             if (-1 != partition_index
-                && err != ERR_CAPACITY_EXCEEDED
-                && err != ERR_NOT_ENOUGH_MEMBER
-                && err != ERR_INVALID_DATA)
+                && err != ERR_CAPACITY_EXCEEDED // no need for reconfiguration on primary
+                && err != ERR_NOT_ENOUGH_MEMBER // primary won't change and we only r/w on primary in this provider
+                )
             {
                 ddebug("clear partition configuration cache %d.%d due to access failure %s",
                        _app_id, partition_index, err.to_string());

--- a/src/dist/replication/test/simple_kv/case-400.act
+++ b/src/dist/replication/test/simple_kv/case-400.act
@@ -19,6 +19,5 @@ client:begin_write:id=1,key=t1,value=v1,timeout=0
 client:end_write:id=1,err=ERR_TIMEOUT,resp=0
 
 # expect the committed decree is 0
-state:{{r1,pri,1,0}}
 state:{{r1,pri,3,0},{r2,sec,3,0},{r3,sec,3,0}}
 


### PR DESCRIPTION
When applications use sync calls for layer 2 rpc calls, the underlying retry becomes useless as the applications always get error code from the initial call. This commit fixes this issues by allowing reusing the same task with additional set_retry method. This is a continue thread for #438 
