### PR TITLE
add make_shared_array() to wrap a dynamic array in std::shared_ptr<T>

### DIFF
--- a/include/dsn/cpp/serialization_helper/thrift_helper.h
+++ b/include/dsn/cpp/serialization_helper/thrift_helper.h
@@ -221,12 +221,12 @@ namespace dsn {
         }
         void resize(std::size_t new_size)
         {
-            std::shared_ptr<char> b(new char[new_size], std::default_delete<char[]>());
+            std::shared_ptr<char> b(dsn::make_shared_array<char>(new_size));
             _buffer.assign(b, 0, static_cast<int>(new_size));
         }
         void assign(const char* ptr, std::size_t size)
         {
-            std::shared_ptr<char> b(new char[size], std::default_delete<char[]>());
+            std::shared_ptr<char> b(dsn::make_shared_array<char>(size));
             memcpy(b.get(), ptr, size);
             _buffer.assign(b, 0, static_cast<int>(size));
         }

--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -111,6 +111,11 @@ struct FTW
 # endif
 
 namespace dsn {
+    template <typename T>
+    std::shared_ptr<T> make_shared_array(size_t size)
+    {
+        return std::shared_ptr<T>(new T[size], std::default_delete<T[]>());
+    }
 
     class blob
     {

--- a/include/dsn/internal/task.h
+++ b/include/dsn/internal/task.h
@@ -429,7 +429,7 @@ public:
 
     void collapse() {
         if (!_unmerged_write_buffers.empty()) {
-            auto buffer = std::shared_ptr<char>(new char[_aio->buffer_size]);
+            std::shared_ptr<char> buffer(dsn::make_shared_array<char>(_aio->buffer_size));
             _merged_write_buffer_holder.assign(buffer, 0, _aio->buffer_size);
             _aio->buffer = buffer.get();
             copy_to(buffer.get());

--- a/src/apps/nfs/nfs_server_impl.cpp
+++ b/src/apps/nfs/nfs_server_impl.cpp
@@ -87,9 +87,7 @@ namespace dsn {
             }
 
             callback_para cp(reply);
-            cp.bb = blob(
-                std::shared_ptr<char>(new char[_opts.nfs_copy_block_bytes], std::default_delete<char[]>{}),
-                _opts.nfs_copy_block_bytes);
+            cp.bb = blob(dsn::make_shared_array<char>(_opts.nfs_copy_block_bytes), _opts.nfs_copy_block_bytes);
             cp.dst_dir = std::move(request.dst_dir);
             cp.file_path = std::move(file_path);
             cp.hfile = hfile;

--- a/src/core/core/message_parser.cpp
+++ b/src/core/core/message_parser.cpp
@@ -56,7 +56,7 @@ namespace dsn {
             // switch to next
             unsigned int sz = (read_next + _buffer_occupied > _buffer_block_size ?
                         read_next + _buffer_occupied : _buffer_block_size);
-            _buffer.assign(std::shared_ptr<char>(new char[sz], std::default_delete<char[]>{}), 0, sz);
+            _buffer.assign(dsn::make_shared_array<char>(sz), 0, sz);
             _buffer_occupied = 0;
 
             // copy

--- a/src/core/core/rpc_message.cpp
+++ b/src/core/core/rpc_message.cpp
@@ -560,7 +560,7 @@ message_ex* message_ex::copy(bool clone_content, bool copy_for_receive)
     else
     {
         int total_length = body_size() + sizeof(dsn::message_header);
-        std::shared_ptr<char> recv_buffer(new char[total_length], std::default_delete<char[]>());
+        std::shared_ptr<char> recv_buffer(dsn::make_shared_array<char>(total_length));
         char* ptr = recv_buffer.get();
         int i=0;
 

--- a/src/core/tools/common/network.sim.cpp
+++ b/src/core/tools/common/network.sim.cpp
@@ -69,7 +69,7 @@ namespace dsn { namespace tools {
 
     static message_ex* virtual_send_message(message_ex* msg)
     {
-        std::shared_ptr<char> buffer(new char[msg->header->body_length + sizeof(message_header)]);
+        std::shared_ptr<char> buffer(dsn::make_shared_array<char>(msg->header->body_length + sizeof(message_header)));
         char* tmp = buffer.get();
 
         for (auto& buf : msg->buffers)

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -248,7 +248,7 @@ namespace  dsn
             // optimization: zero-copy
             if (!blob.buffer_ptr())
             {
-                std::shared_ptr<char> buffer(new char[len], [](char* ptr){ delete []ptr; });
+                std::shared_ptr<char> buffer(::dsn::make_shared_array<char>(len));
                 memcpy(buffer.get(), blob.data(), blob.length());
                 blob = ::dsn::blob(buffer, 0, blob.length());
             }
@@ -364,7 +364,7 @@ namespace  dsn
 
     void binary_writer::create_new_buffer(size_t size, /*out*/blob& bb)
     {
-        bb.assign(std::shared_ptr<char>(new char[size], std::default_delete<char[]>{}), 0, (int)size);
+        bb.assign(::dsn::make_shared_array<char>(size), 0, (int)size);
     }
 
     void binary_writer::commit()
@@ -387,7 +387,7 @@ namespace  dsn
         }
         else
         {
-            std::shared_ptr<char> bptr(new char[_total_size], [](char* ptr){ delete []ptr; });
+            std::shared_ptr<char> bptr(::dsn::make_shared_array<char>(_total_size));
             blob bb(bptr, _total_size);
             const char* ptr = bb.data();
 
@@ -408,7 +408,7 @@ namespace  dsn
         }
         else
         {
-            std::shared_ptr<char> bptr(new char[_total_size], [](char* ptr){ delete []ptr; });
+            std::shared_ptr<char> bptr(::dsn::make_shared_array<char>(_total_size));
             blob bb(bptr, _total_size);
             const char* ptr = bb.data();
 

--- a/src/dist/replication/lib/replication_app_base.cpp
+++ b/src/dist/replication/lib/replication_app_base.cpp
@@ -134,7 +134,7 @@ error_code replica_app_info::load(const char* file)
         return ERR_FILE_OPERATION_FAILED;
     }
 
-    std::shared_ptr<char> buffer(new char[sz]);
+    std::shared_ptr<char> buffer(dsn::make_shared_array<char>(sz));
     is.read((char*)buffer.get(), sz);
     is.close();
     

--- a/src/dist/replication/meta_server/dump_file.h
+++ b/src/dist/replication/meta_server/dump_file.h
@@ -136,7 +136,7 @@ public:
             }
         }
 
-        std::shared_ptr<char> ptr(new char[hdr.length], [](char* raw){ delete []raw; });
+        std::shared_ptr<char> ptr(dsn::make_shared_array<char>(hdr.length));
         char* raw_mem = ptr.get();
         len = 0;
         while (len < hdr.length)

--- a/src/dist/replication/meta_server/meta_state_service_simple.cpp
+++ b/src/dist/replication/meta_server/meta_state_service_simple.cpp
@@ -269,7 +269,7 @@ namespace dsn
                         {
                             break;
                         }
-                        std::shared_ptr<char> buffer(new char[header.size]);
+                        std::shared_ptr<char> buffer(dsn::make_shared_array<char>(header.size));
                         if (fread(buffer.get(), header.size, 1, fd) != 1)
                         {
                             break;
@@ -440,7 +440,7 @@ namespace dsn
             }
             else {
                 //apply
-                std::shared_ptr<char> batch(new char[total_size], [](char* ptr){ delete []ptr; } );
+                std::shared_ptr<char> batch(dsn::make_shared_array<char>(total_size));
                 char* dest = batch.get();
                 std::for_each(batch_buffer.begin(), batch_buffer.end(),
                     [&dest](const blob& entry)

--- a/src/dist/replication/test/meta_test/unit_test/state_sync_test.cpp
+++ b/src/dist/replication/test/meta_test/unit_test/state_sync_test.cpp
@@ -44,7 +44,7 @@ static void random_assign_partition_config(
 static void file_data_compare(const char* fname1, const char* fname2)
 {
     static const int length = 4096;
-    std::shared_ptr<char> buffer(new char[length*2], std::default_delete<char[]>{});
+    std::shared_ptr<char> buffer(dsn::make_shared_array<char>(length*2));
     char* buf1 = buffer.get(), *buf2 = buffer.get()+length;
 
     std::ifstream ifile1(fname1, std::ios::in|std::ios::binary);

--- a/src/dist/replication/zookeeper/meta_state_service_zookeeper.cpp
+++ b/src/dist/replication/zookeeper/meta_state_service_zookeeper.cpp
@@ -419,7 +419,7 @@ void meta_state_service_zookeeper::visit_zookeeper_internal(
             [op](meta_state_service::err_value_callback& cb){
                 blob data;
                 if (ZOK == op->_output.error) {
-                    std::shared_ptr<char> buf(new char[op->_output.get_op.value_length]);
+                    std::shared_ptr<char> buf(dsn::make_shared_array<char>(op->_output.get_op.value_length));
                     memcpy(buf.get(), op->_output.get_op.value, op->_output.get_op.value_length);
                     data.assign(buf, 0, op->_output.get_op.value_length);
                 }

--- a/src/tests/dsn/dump_file.cpp
+++ b/src/tests/dsn/dump_file.cpp
@@ -4,7 +4,7 @@
 TEST(dump_file, read_write)
 {
     unsigned int total_length = 4096;
-    std::shared_ptr<char> buffer(new char[total_length], [](char* output){ delete []output; });
+    std::shared_ptr<char> buffer(dsn::make_shared_array<char>(total_length));
     char* ptr = buffer.get();
     for (int i=0; i!=total_length; ++i)
         ptr[i] = i%256;
@@ -36,7 +36,7 @@ TEST(dump_file, read_write)
         std::shared_ptr<dump_file> f = dump_file::open_file("test_file", false);
         ASSERT_TRUE(f != nullptr);
 
-        std::shared_ptr<char> out_buffer(new char[total_length], [](char* output){ delete []output; });
+        std::shared_ptr<char> out_buffer(dsn::make_shared_array<char>(total_length));
         ptr = out_buffer.get();
         dsn::blob bb;
         int block_offset = 0;


### PR DESCRIPTION
refer to #444 
