### PR TITLE
decouple message parsers from the core to enable later plugins

### DIFF
--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -632,23 +632,6 @@ extern DSN_API void         dsn_msg_get_options(
                                 /*out*/ dsn_msg_options_t* opts
                                 );
 
-/*! rpc message header type */
-typedef enum dsn_msg_header_type {
-    DHT_INVALID = 0,
-    DHT_DEFAULT = 1,
-    DHT_THRIFT = 2,
-    DHT_HTTP = 3,
-} dsn_msg_header_type;
-
-/*!
- get the message header type
-
- \param msg  the message handle
- */
-extern DSN_API dsn_msg_header_type dsn_msg_get_header_type(
-                                dsn_message_t msg
-                                );
-
 DSN_API void dsn_msg_set_serailize_format(dsn_message_t msg, dsn_msg_serialize_format fmt);
 
 DSN_API dsn_msg_serialize_format dsn_msg_get_serialize_format(dsn_message_t msg);

--- a/include/dsn/internal/message_parser.h
+++ b/include/dsn/internal/message_parser.h
@@ -130,6 +130,10 @@ namespace dsn
         // return buffer count used, which must be no more than the return value of get_buffer_count_on_send().
         // may be invoked for mutiple times if the message is reused for resending.
         virtual int get_buffers_on_send(message_ex* msg, /*out*/ send_buf* buffers) = 0;
+
+    public:
+        static network_header_format get_header_type(const char* bytes); // buffer size >= sizeof(uint32_t)
+        static std::string get_debug_string(const char* bytes);
     };
 
     class message_parser_manager : public utils::singleton<message_parser_manager>
@@ -149,7 +153,7 @@ namespace dsn
         message_parser_manager();
 
         // called only during system init, thread-unsafe
-        void register_factory(network_header_format fmt, message_parser::factory f, message_parser::factory2 f2, size_t sz);
+        void register_factory(network_header_format fmt, const std::vector<const char*>& signatures, message_parser::factory f, message_parser::factory2 f2, size_t sz);
 
         message_parser* create_parser(network_header_format fmt);
         const parser_factory_info& get(network_header_format fmt) { return _factory_vec[fmt]; }

--- a/include/dsn/internal/rpc_message.h
+++ b/include/dsn/internal/rpc_message.h
@@ -64,54 +64,9 @@ namespace dsn
                              // we leverage for optimization (fast rpc handler lookup)
     };
 
-    struct header_type
-    {
-    public:
-        union
-        {
-            char stype[4];
-            int32_t itype;
-        } type;
-        header_type()
-        {
-            type.itype = -1;
-        }
-        header_type(const char* str)
-        {
-            memcpy(type.stype, str, sizeof(int32_t));
-        }
-        header_type(const header_type& another)
-        {
-            type.itype = another.type.itype;
-        }
-        header_type& operator=(const header_type& another)
-        {
-            type.itype = another.type.itype;
-            return *this;
-        }
-        bool operator==(const header_type& other) const
-        {
-            return type.itype == other.type.itype;
-        }
-        bool operator!=(const header_type& other) const
-        {
-            return type.itype != other.type.itype;
-        }
-        std::string debug_string() const;
-    public:
-        static header_type hdr_type_dsn;
-        static header_type hdr_type_thrift;
-        static header_type hdr_type_http_get;
-        static header_type hdr_type_http_post;
-        static header_type hdr_type_http_options;
-        static header_type hdr_type_http_response;
-        static bool header_type_to_format(const header_type& hdr_type, /*out*/ network_header_format& hdr_format);
-        static dsn_msg_header_type header_type_to_c_type(const header_type& hdr_type);
-    };
-
     typedef struct message_header
     {
-        header_type    hdr_type;
+        uint32_t       hdr_type;
         uint32_t       hdr_version;
         uint32_t       hdr_length;
         uint32_t       hdr_crc32;

--- a/include/dsn/internal/task_spec.h
+++ b/include/dsn/internal/task_spec.h
@@ -160,9 +160,8 @@ ENUM_END(dsn_msg_serialize_format)
 
 // define network header format for RPC
 DEFINE_CUSTOMIZED_ID_TYPE(network_header_format)
+DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_INVALID)
 DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_DSN)
-DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_THRIFT)
-DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_HTTP)
 
 // define network channel types for RPC
 DEFINE_CUSTOMIZED_ID_TYPE(rpc_channel)

--- a/include/dsn/tool_api.h
+++ b/include/dsn/tool_api.h
@@ -132,7 +132,7 @@ namespace internal_use_only
     bool register_component_provider(const char* name, logging_provider::factory f, ::dsn::provider_type type);
     bool register_component_provider(const char* name, memory_provider::factory f, ::dsn::provider_type type);
     bool register_component_provider(const char* name, nfs_node::factory f, ::dsn::provider_type type);
-    bool register_component_provider(network_header_format fmt, message_parser::factory f, message_parser::factory2 f2, size_t sz);
+    bool register_component_provider(network_header_format fmt, const std::vector<const char*>& signatures, message_parser::factory f, message_parser::factory2 f2, size_t sz);
     bool register_toollet(const char* name, toollet::factory f, ::dsn::provider_type type);
     bool register_tool(const char* name, tool_app::factory f, ::dsn::provider_type type);
     toollet* get_toollet(const char* name, ::dsn::provider_type type);
@@ -144,7 +144,7 @@ extern join_point<void, sys_exit_type>     sys_exit;
 
 template <typename T> bool register_component_provider(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, ::dsn::PROVIDER_TYPE_MAIN); }
 template <typename T> bool register_component_aspect(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, ::dsn::PROVIDER_TYPE_ASPECT); }
-template <typename T> bool register_message_header_parser(network_header_format fmt);
+template <typename T> bool register_message_header_parser(network_header_format fmt, const std::vector<const char*>& signatures);
 
 template <typename T> bool register_toollet(const char* name) { return internal_use_only::register_toollet(name, toollet::template create<T>, ::dsn::PROVIDER_TYPE_MAIN); }
 template <typename T> bool register_tool(const char* name) { return internal_use_only::register_tool(name, tool_app::template create<T>, ::dsn::PROVIDER_TYPE_MAIN); }
@@ -156,9 +156,9 @@ const char* get_service_node_name(service_node* node);
 bool is_engine_ready();
 
 // --------- inline implementation -----------------------------
-template <typename T> bool register_message_header_parser(network_header_format fmt) 
+template <typename T> bool register_message_header_parser(network_header_format fmt, const std::vector<const char*>& signatures)
 {
-    return internal_use_only::register_component_provider(fmt, T::template create<T>, T::template create2<T>, sizeof(T));
+    return internal_use_only::register_component_provider(fmt, signatures, T::template create<T>, T::template create2<T>, sizeof(T));
 }
 
 }} // end namespace dsn::tools

--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -260,15 +260,16 @@ namespace dsn
 
     int rpc_session::prepare_parser()
     {
-        if (_reader._buffer_occupied < sizeof(header_type))
-            return sizeof(header_type) - _reader._buffer_occupied;
+        if (_reader._buffer_occupied < sizeof(uint32_t))
+            return sizeof(uint32_t) - _reader._buffer_occupied;
 
-        header_type hdr_type(_reader._buffer.data());
-        network_header_format hdr_format(NET_HDR_DSN);
-        if (!header_type::header_type_to_format(hdr_type, hdr_format))
+        auto hdr_format = message_parser::get_header_type(_reader._buffer.data());
+        if (hdr_format == NET_HDR_INVALID)
         {
             derror("invalid header type, remote_client = %s, header_type = '%s'",
-                   _remote_addr.to_string(), hdr_type.debug_string().c_str());
+                _remote_addr.to_string(),
+                message_parser::get_debug_string(_reader._buffer.data()).c_str()
+            );
             return -1;
         }
 

--- a/src/core/core/rpc_engine.cpp
+++ b/src/core/core/rpc_engine.cpp
@@ -589,10 +589,11 @@ namespace dsn {
         _client_nets.resize(network_header_format::max_value() + 1);
 
         // for each format
-        for (int i = 0; i <= network_header_format::max_value(); i++)
+        for (int i = NET_HDR_INVALID + 1; i <= network_header_format::max_value(); i++)
         {
             std::vector<network*>& pnet = _client_nets[i];
             pnet.resize(rpc_channel::max_value() + 1);
+            auto client_hdr_format = network_header_format(network_header_format::to_string(i));
 
             // for each channel
             for (int j = 0; j <= rpc_channel::max_value(); j++)
@@ -616,8 +617,6 @@ namespace dsn {
                 network_server_config cs(aspec.id, c);
                 cs.factory_name = factory;
                 cs.message_buffer_block_size = blk_size;
-
-                auto client_hdr_format = network_header_format(network_header_format::to_string(i));
 
                 auto net = create_network(cs, true, client_hdr_format, ctx);
                 if (!net) return ERR_NETWORK_INIT_FAILED;
@@ -695,7 +694,7 @@ namespace dsn {
         _uri_resolver_mgr.reset(new uri_resolver_manager(
             service_engine::fast_instance().spec().config.get()));
 
-        _local_primary_address = _client_nets[0][0]->address();
+        _local_primary_address = _client_nets[NET_HDR_DSN][0]->address();
         _local_primary_address.c_addr_ptr()->u.v4.port = aspec.ports.size() > 0 ? *aspec.ports.begin() : aspec.id + ctx.port_shift_value;
 
         ddebug("=== service_node=[%s], primary_address=[%s] ===",

--- a/src/core/core/rpc_message.cpp
+++ b/src/core/core/rpc_message.cpp
@@ -199,86 +199,10 @@ DSN_API void dsn_msg_get_options(
     opts->gpid = hdr->gpid;
 }
 
-DSN_API dsn_msg_header_type dsn_msg_get_header_type(
-    dsn_message_t msg
-    )
-{
-    auto hdr = ((::dsn::message_ex*)msg)->header;
-    return dsn::header_type::header_type_to_c_type(hdr->hdr_type);
-}
-
 namespace dsn {
 
 std::atomic<uint64_t> message_ex::_id(0);
 uint32_t message_ex::s_local_hash = 0;
-
-header_type header_type::hdr_type_dsn("RDSN");
-header_type header_type::hdr_type_thrift("THFT");
-header_type header_type::hdr_type_http_get("GET ");
-header_type header_type::hdr_type_http_post("POST");
-header_type header_type::hdr_type_http_options("OPTI"); 
-header_type header_type::hdr_type_http_response("HTTP");
-
-std::string header_type::debug_string() const
-{
-    char buf[20];
-    char* ptr = buf;
-    for (int i = 0; i < 4; ++i) {
-        auto& c = type.stype[i];
-        if (isprint(c)) {
-            *ptr++ = c;
-        }
-        else {
-            sprintf(ptr, "\\%02X", c);
-            ptr += 3;
-        }
-    }
-    *ptr = '\0';
-    return std::string(buf);
-}
-
-bool header_type::header_type_to_format(const header_type& hdr_type, /*out*/ network_header_format& hdr_format)
-{
-    if (hdr_type == hdr_type_dsn)
-    {
-        hdr_format = NET_HDR_DSN;
-        return true;
-    }
-    else if (hdr_type == hdr_type_thrift)
-    {
-        hdr_format = NET_HDR_THRIFT;
-        return true;
-    }
-    else if (hdr_type == hdr_type_http_options
-        || hdr_type == hdr_type_http_get 
-        || hdr_type == hdr_type_http_post 
-        || hdr_type == hdr_type_http_response
-        )
-    {
-        hdr_format = NET_HDR_HTTP;
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-dsn_msg_header_type header_type::header_type_to_c_type(const header_type& hdr_type)
-{
-    if (hdr_type == hdr_type_dsn)
-        return DHT_DEFAULT;
-    else if (hdr_type == hdr_type_thrift)
-        return DHT_THRIFT;
-    else if (hdr_type == hdr_type_http_get 
-        || hdr_type == hdr_type_http_post 
-        || hdr_type == hdr_type_http_options
-        || hdr_type == hdr_type_http_response
-        )
-        return DHT_HTTP;
-    else
-        return DHT_INVALID;
-}
 
 message_ex::message_ex()
     : header(nullptr), local_rpc_code(::dsn::TASK_CODE_INVALID), hdr_format(NET_HDR_DSN), send_retry_count(0),
@@ -459,7 +383,7 @@ message_ex* message_ex::create_request(dsn_task_code_t rpc_code, int timeout_mil
     // init header
     auto& hdr = *msg->header;
     memset(&hdr, 0, sizeof(hdr));
-    hdr.hdr_type = header_type::hdr_type_dsn;
+    hdr.hdr_type = *(uint32_t*)"RDSN";
     hdr.hdr_length = sizeof(message_header);
     hdr.hdr_crc32 = hdr.body_crc32 = CRC_INVALID;
 

--- a/src/core/core/tool_api.cpp
+++ b/src/core/core/tool_api.cpp
@@ -228,9 +228,9 @@ namespace dsn {
                 return dsn::utils::factory_store<memory_provider>::register_factory(name, f, type);
             }
 
-            bool register_component_provider(network_header_format fmt, message_parser::factory f, message_parser::factory2 f2, size_t sz)
+            bool register_component_provider(network_header_format fmt, const std::vector<const char*>& signatures, message_parser::factory f, message_parser::factory2 f2, size_t sz)
             {
-                message_parser_manager::instance().register_factory(fmt, f, f2, sz);
+                message_parser_manager::instance().register_factory(fmt, signatures, f, f2, sz);
                 return true;
             }
 

--- a/src/core/tools/common/asio_net_provider.cpp
+++ b/src/core/tools/common/asio_net_provider.cpp
@@ -185,18 +185,20 @@ namespace dsn {
                         return;
                     }
 
-                    if (bytes_transferred < sizeof(header_type))
+                    if (bytes_transferred < sizeof(uint32_t))
                     {
                         derror("%s: asio udp read failed: too short message", _address.to_string());
                         do_receive();
                         return;
                     }
 
-                    header_type hdr_type(_recv_reader._buffer.data());
-                    network_header_format hdr_format(NET_HDR_DSN);
-                    if (!header_type::header_type_to_format(hdr_type, hdr_format))
+                    auto hdr_format = message_parser::get_header_type(_recv_reader._buffer.data());
+                    if (NET_HDR_INVALID == hdr_format)
                     {
-                        derror("%s: asio udp read failed: invalid header type '%s'", _address.to_string(), hdr_type.debug_string().c_str());
+                        derror("%s: asio udp read failed: invalid header type '%s'", 
+                            _address.to_string(), 
+                            message_parser::get_debug_string(_recv_reader._buffer.data()).c_str()
+                            );
                         do_receive();
                         return;
                     }
@@ -291,10 +293,10 @@ namespace dsn {
             }
 
             _parsers.resize(network_header_format::max_value() + 1);
-            for (int i = 0; i <= network_header_format::max_value(); i++)
+            for (int i = NET_HDR_INVALID + 1; i <= network_header_format::max_value(); i++)
             {
-                auto hdr_format = network_header_format(network_header_format::to_string(i));
-                _parsers[i] = new_message_parser(hdr_format);
+                auto client_hdr_format = network_header_format(network_header_format::to_string(i));
+                _parsers[i] = new_message_parser(client_hdr_format);
             }
 
             do_receive();

--- a/src/core/tools/common/http_message_parser.cpp
+++ b/src/core/tools/common/http_message_parser.cpp
@@ -316,22 +316,22 @@ http_message_parser::http_message_parser()
         message_header* header = owner->_current_message->header;
         if (parser->type == HTTP_REQUEST && parser->method == HTTP_GET)
         {
-            header->hdr_type = header_type::hdr_type_http_get;
+            header->hdr_type = *(uint32_t*)"GET ";
             header->context.u.is_request = 1;
         }
         else if (parser->type == HTTP_REQUEST && parser->method == HTTP_POST)
         {
-            header->hdr_type = header_type::hdr_type_http_post;
+            header->hdr_type = *(uint32_t*)"POST";
             header->context.u.is_request = 1;
         }
         else if (parser->type == HTTP_REQUEST && parser->method == HTTP_OPTIONS)
         {
-            header->hdr_type = header_type::hdr_type_http_options;
+            header->hdr_type = *(uint32_t*)"OPTI";
             header->context.u.is_request = 1;
         }        
         else if (parser->type == HTTP_RESPONSE)
         {
-            header->hdr_type = header_type::hdr_type_http_response;
+            header->hdr_type = *(uint32_t*)"HTTP";
             header->context.u.is_request = 0;
         }        
         else

--- a/src/core/tools/common/http_message_parser.h
+++ b/src/core/tools/common/http_message_parser.h
@@ -45,6 +45,8 @@
 
 namespace dsn
 {
+    DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_HTTP)
+
     class http_message_parser : public message_parser
     {
     public:

--- a/src/core/tools/common/providers.common.cpp
+++ b/src/core/tools/common/providers.common.cpp
@@ -69,10 +69,11 @@ namespace dsn {
             register_component_provider<sim_network_provider>("dsn::tools::sim_network_provider");
             register_component_provider<simple_task_queue>("dsn::tools::simple_task_queue");
             register_component_provider<simple_timer_service>("dsn::tools::simple_timer_service");
+            
+            register_message_header_parser<dsn_message_parser>(NET_HDR_DSN, {"RDSN"});
+            register_message_header_parser<thrift_message_parser>(NET_HDR_THRIFT, {"THFT"});
+            register_message_header_parser<http_message_parser>(NET_HDR_HTTP, {"GET ", "POST", "OPTI", "HTTP"});
 
-            register_message_header_parser<dsn_message_parser>(NET_HDR_DSN);
-            register_message_header_parser<thrift_message_parser>(NET_HDR_THRIFT);
-            register_message_header_parser<http_message_parser>(NET_HDR_HTTP);
 #if defined(_WIN32)
             register_component_provider<native_win_aio_provider>("dsn::tools::native_aio_provider");
 #elif defined(__linux__)

--- a/src/core/tools/common/thrift_message_parser.cpp
+++ b/src/core/tools/common/thrift_message_parser.cpp
@@ -212,7 +212,7 @@ namespace dsn
 
     void thrift_message_parser::read_thrift_header(const char* buffer, /*out*/ thrift_message_header& header)
     {
-        header.hdr_type = header_type(buffer);
+        header.hdr_type = *(uint32_t*)(buffer);
         buffer += sizeof(int32_t);
         header.hdr_version = be32toh( *(int32_t*)(buffer) );
         buffer += sizeof(int32_t);
@@ -235,11 +235,12 @@ namespace dsn
 
     bool thrift_message_parser::check_thrift_header(const thrift_message_header& header)
     {
-        if (header.hdr_type != header_type::hdr_type_thrift)
+        if (header.hdr_type != THRIFT_HDR_SIG)
         {
             derror("hdr_type should be %s, but %s",
-                   header_type::hdr_type_thrift.debug_string().c_str(),
-                   header.hdr_type.debug_string().c_str());
+                message_parser::get_debug_string("THFT").c_str(),
+                message_parser::get_debug_string((const char*)&header.hdr_type).c_str()
+                );
             return false;
         }
         if (header.hdr_version != 0)
@@ -272,7 +273,7 @@ namespace dsn
         iprot.readMessageBegin(fname, mtype, seqid);
         dinfo("rpc name: %s, type: %d, seqid: %d", fname.c_str(), mtype, seqid);
 
-        dsn_hdr->hdr_type = header_type::hdr_type_thrift;
+        dsn_hdr->hdr_type = THRIFT_HDR_SIG;
         dsn_hdr->hdr_length = sizeof(message_header);
         dsn_hdr->body_length = thrift_header.body_length;
         dsn_hdr->hdr_crc32 = dsn_hdr->body_crc32 = CRC_INVALID;

--- a/src/core/tools/common/thrift_message_parser.h
+++ b/src/core/tools/common/thrift_message_parser.h
@@ -44,7 +44,7 @@ namespace dsn
     // request header (in big-endian)
     struct thrift_message_header
     {
-        header_type    hdr_type; ///< must be "THFT"
+        uint32_t       hdr_type; ///< must be "THFT"
         uint32_t       hdr_version; ///< must be 0
         uint32_t       hdr_length; ///< must be sizeof(thrift_message_header)
         uint32_t       hdr_crc32;
@@ -59,6 +59,10 @@ namespace dsn
 
     // response format:
     //     <total_len(int32)> <thrift_string> <thrift_message_begin> <body_data(bytes)> <thrift_message_end>
+
+# define THRIFT_HDR_SIG (*(uint32_t*)"THFT")
+
+    DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_THRIFT)       
 
     class thrift_message_parser : public message_parser
     {


### PR DESCRIPTION
decouple message parsers from the core to enable later plugins such as raw or GRPC message parsers
