### PR TITLE
create parser on demand in asio_udp_provider; fix memory leak in rpc_…

### DIFF
--- a/include/dsn/internal/network.h
+++ b/include/dsn/internal/network.h
@@ -126,7 +126,7 @@ namespace dsn {
         //  (1) extracing blob from a RPC request message for low layer'
         //  (2) parsing a incoming blob message to get the rpc_message
         //
-        message_parser_ptr new_message_parser(network_header_format hdr_format);
+        message_parser* new_message_parser(network_header_format hdr_format);
 
         // for in-place new message parser
         std::pair<message_parser::factory2, size_t> get_message_parser_info(network_header_format hdr_format);

--- a/src/core/core/network.cpp
+++ b/src/core/core/network.cpp
@@ -462,6 +462,9 @@ namespace dsn
             if (is_client() && msg->header->from_address == _net.engine()->primary_address())
             {
                 derror("self connection detected, address = %s", msg->header->from_address.to_string());
+                dassert(msg->get_count() == 0,
+                    "message should not be referenced by anybody so far");
+                delete msg;
                 return false;
             }
 
@@ -521,7 +524,7 @@ namespace dsn
         _engine->matcher()->on_recv_reply(this, id, msg, delay_ms);
     }
 
-    message_parser_ptr network::new_message_parser(network_header_format hdr_format)
+    message_parser* network::new_message_parser(network_header_format hdr_format)
     {
         message_parser* parser = message_parser_manager::instance().create_parser(hdr_format);
         dassert(parser, "message parser '%s' not registerd or invalid!", hdr_format.to_string());

--- a/src/core/tools/common/network.sim.cpp
+++ b/src/core/tools/common/network.sim.cpp
@@ -105,7 +105,7 @@ namespace dsn { namespace tools {
                 if (nullptr == server_session)
                 {
                     rpc_session_ptr cptr = this;
-                    message_parser_ptr parser = _net.new_message_parser(msg->hdr_format);
+                    message_parser_ptr parser(_net.new_message_parser(msg->hdr_format));
                     server_session = new sim_server_session(*rnet, _net.address(), 
                         cptr, parser);
                     rnet->on_server_session_accepted(server_session);

--- a/src/core/tools/common/network.sim.h
+++ b/src/core/tools/common/network.sim.h
@@ -92,7 +92,7 @@ namespace dsn { namespace tools {
 
         virtual rpc_session_ptr create_client_session(::dsn::rpc_address server_addr)
         {
-            auto parser = new_message_parser(_client_hdr_format);
+            message_parser_ptr parser(new_message_parser(_client_hdr_format));
             return rpc_session_ptr(new sim_client_session(*this, server_addr, parser));
         }
 

--- a/src/core/tools/hpc/hpc_network_provider.bsd.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.bsd.cpp
@@ -172,7 +172,7 @@ namespace dsn
 
             auto sock = create_tcp_socket(&addr);
             dassert(sock != -1, "create client tcp socket failed!");
-            auto parser = new_message_parser(_client_hdr_format);
+            message_parser_ptr parser(new_message_parser(_client_hdr_format));
             auto client = new hpc_rpc_session(sock, parser, *this, server_addr, true);
             rpc_session_ptr c(client);
             client->bind_looper(_looper, true);

--- a/src/core/tools/hpc/hpc_network_provider.linux.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.linux.cpp
@@ -172,7 +172,7 @@ namespace dsn
 
             auto sock = create_tcp_socket(&addr);
             dassert(sock != -1, "create client tcp socket failed!");
-            auto parser = new_message_parser(_client_hdr_format);
+            message_parser_ptr parser(new_message_parser(_client_hdr_format));
             auto client = new hpc_rpc_session(sock, parser, *this, server_addr, true);
             rpc_session_ptr c(client);
             client->bind_looper(_looper, true);

--- a/src/core/tools/hpc/hpc_network_provider.win.cpp
+++ b/src/core/tools/hpc/hpc_network_provider.win.cpp
@@ -249,7 +249,7 @@ namespace dsn
             addr.sin_port = 0;
 
             auto sock = create_tcp_socket(&addr);
-            auto parser = new_message_parser(_client_hdr_format);
+            message_parser_ptr parser(new_message_parser(_client_hdr_format));
             auto client = new hpc_rpc_session(sock, parser, *this, server_addr, true);
             rpc_session_ptr c(client);
             client->bind_looper(_looper);


### PR DESCRIPTION
…session::on_recv_message(); only notify disconnect for server session
- create parser on demand in asio_udp_provider, to avoid unnecessarily registering join point in raw_message_parser;
- only notify disconnect for server session, because client session should be receive rpc request
