### PR TITLE
add config [core.logging_flush_on_exit]

### DIFF
--- a/src/core/core/coredump.posix.cpp
+++ b/src/core/core/coredump.posix.cpp
@@ -70,6 +70,7 @@ namespace dsn {
         static void handle_core_dump(int signal_id)
         {
             printf("got signal id: %d\n", signal_id);
+            fflush(stdout);
             /*
              * firstly we must set the sig_handler to default,
              * to prevent the possible inifinite loop

--- a/src/core/core/logging.cpp
+++ b/src/core/core/logging.cpp
@@ -62,7 +62,12 @@ void dsn_log_init()
     dassert(dsn_log_start_level != dsn_log_level_t::LOG_LEVEL_INVALID, "invalid [core] logging_start_level specified");
 
     // register log flush on exit
-    ::dsn::tools::sys_exit.put_back(log_on_sys_exit, "log.flush");
+    bool logging_flush_on_exit = dsn_config_get_value_bool("core", "logging_flush_on_exit",
+        true, "flush log when exit system");
+    if (logging_flush_on_exit)
+    {
+        ::dsn::tools::sys_exit.put_back(log_on_sys_exit, "log.flush");
+    }
 }
 
 DSN_API dsn_log_level_t dsn_log_get_start_level()


### PR DESCRIPTION
because when the core is caused by printing log, then logging flush on exit will cause dead lock. so I add an option to disable it.
