### PR TITLE
fix bug in replication_app_base::get_checkpoint()

### DIFF
--- a/include/dsn/cpp/replicated_service_app.h
+++ b/include/dsn/cpp/replicated_service_app.h
@@ -102,7 +102,6 @@ namespace dsn
             {
                 bool succ = true;
 
-                state.total_learn_state_size = sizeof(dsn_app_learn_state);
                 state.from_decree_excluded = from_decree_excluded;
                 state.to_decree_included = to_decree_included;
                 state.meta_state_size = meta_state.length();
@@ -116,8 +115,11 @@ namespace dsn
                     {
                         succ = false;
                     }
-                    state.meta_state_ptr = ptr;
-                    if (succ) memcpy(ptr, meta_state.data(), state.meta_state_size);
+                    if (succ)
+                    {
+                        state.meta_state_ptr = ptr;
+                        memcpy(ptr, meta_state.data(), state.meta_state_size);
+                    }
                     ptr += state.meta_state_size;
                 }
                 else

--- a/src/dist/replication/lib/replication_app_base.cpp
+++ b/src/dist/replication/lib/replication_app_base.cpp
@@ -408,7 +408,7 @@ error_code replication_app_base::open_new_internal(replica* r, int64_t shared_lo
             dassert(need_size > capacity, "");
             capacity = need_size;
             buffer = dsn_transient_malloc(capacity);
-            dsn_app_learn_state* lstate = reinterpret_cast<dsn_app_learn_state*>(buffer);
+            lstate = reinterpret_cast<dsn_app_learn_state*>(buffer);
             err = _callbacks.calls.get_checkpoint(
                 _app_context_callbacks, learn_start, last_committed_decree(),
                 (void*)learn_request.data(), learn_request.length(), lstate, capacity);


### PR DESCRIPTION
in replication_app_base::get_checkpoint(), the lstate is shield by local variable, which may cause coredump.
