### PR TITLE
fix learn_dir check bug: learn_dir may be not exist on load

### DIFF
--- a/src/dist/replication/lib/replication_app_base.cpp
+++ b/src/dist/replication/lib/replication_app_base.cpp
@@ -232,13 +232,7 @@ error_code replication_app_base::open_internal(replica* r)
 {
     if (!dsn::utils::filesystem::directory_exists(_dir_data))
     {
-        derror("replica dir %s does not exit", _dir_data.c_str());
-        return ERR_FILE_OPERATION_FAILED;
-    }
-
-    if (!dsn::utils::filesystem::directory_exists(_dir_learn))
-    {
-        derror("replica dir %s does not exit", _dir_learn.c_str());
+        derror("%s: replica data dir %s does not exist", r->name(), _dir_data.c_str());
         return ERR_FILE_OPERATION_FAILED;
     }
 
@@ -268,23 +262,12 @@ error_code replication_app_base::open_internal(replica* r)
 
 error_code replication_app_base::open_new_internal(replica* r, int64_t shared_log_start, int64_t private_log_start)
 {
-    auto dir = data_dir();
-    dsn::utils::filesystem::remove_path(dir);
-    dsn::utils::filesystem::create_directory(dir);
-
-    dir = learn_dir();
-    dsn::utils::filesystem::remove_path(dir);
-    dsn::utils::filesystem::create_directory(dir);
+    dsn::utils::filesystem::remove_path(_dir_data);
+    dsn::utils::filesystem::create_directory(_dir_data);
 
     if (!dsn::utils::filesystem::directory_exists(_dir_data))
     {
-        derror("%s: replica dir %s does not exit", r->name(), _dir_data.c_str());
-        return ERR_FILE_OPERATION_FAILED;
-    }
-
-    if (!dsn::utils::filesystem::directory_exists(_dir_learn))
-    {
-        derror("%s: replica dir %s does not exit", r->name(), _dir_learn.c_str());
+        derror("%s: create replica data dir %s failed", r->name(), _dir_data.c_str());
         return ERR_FILE_OPERATION_FAILED;
     }
 


### PR DESCRIPTION
If server coredump when learning, at the point of learn_dir removed but not created in replica::on_learn_reply(), then the learn_dir will be not exist, and will coredump at the next loading.

So we will not create learn_dir when creating new replica, and also not check learn_dir when loading replica. The learn_dir will be created on need when learning.
