### PR TITLE
improve mutation_data write_to/read_from

### DIFF
--- a/include/dsn/cpp/blob.h
+++ b/include/dsn/cpp/blob.h
@@ -238,6 +238,8 @@ namespace dsn
         binary_writer(blob& buffer);
         virtual ~binary_writer();
 
+        virtual void flush();
+
         template<typename T> void write_pod(const T& val);
         template<typename T> void write(const T& val) { dassert(false, "write of this type is not implemented"); }
         void write(const int8_t& val) { write_pod(val); }

--- a/include/dsn/cpp/rpc_stream.h
+++ b/include/dsn/cpp/rpc_stream.h
@@ -122,8 +122,14 @@ namespace dsn
             }
         }
 
-        ~rpc_write_stream()
+        virtual ~rpc_write_stream()
         {
+            flush();
+        }
+
+        virtual void flush() override
+        {
+            binary_writer::flush();
             commit_buffer();
         }
         

--- a/include/dsn/tool-api/rpc_message.h
+++ b/include/dsn/tool-api/rpc_message.h
@@ -151,6 +151,7 @@ namespace dsn
         //        
         DSN_API void write_next(void** ptr, size_t* size, size_t min_size);
         DSN_API void write_commit(size_t size);
+        DSN_API void write_append(const blob& data);
         DSN_API bool read_next(void** ptr, size_t* size);
         DSN_API void read_commit(size_t size);
         size_t body_size() { return (size_t)header->body_length; }

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -527,6 +527,22 @@ void message_ex::write_commit(size_t size)
     this->header->body_length += (int)size;
 }
 
+void message_ex::write_append(const blob& data)
+{
+    // printf("%p %s\n", this, __FUNCTION__);
+    dassert(!this->_is_read && this->_rw_committed, "there are pending msg write not committed"
+        ", please invoke dsn_msg_write_next and dsn_msg_write_commit in pairs");
+
+    int size = data.length();
+    if (size > 0)
+    {
+        this->_rw_index++;
+        this->_rw_offset += size;
+        this->buffers.push_back(data);
+        this->header->body_length += size;
+    }
+}
+
 bool message_ex::read_next(void** ptr, size_t* size)
 {
     // printf("%p %s %d\n", this, __FUNCTION__, utils::get_current_tid());

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -356,6 +356,11 @@ namespace  dsn
     {
     }
 
+    void binary_writer::flush()
+    {
+        commit();
+    }
+
     void binary_writer::create_buffer(size_t size)
     {
         commit();
@@ -387,6 +392,7 @@ namespace  dsn
     blob binary_writer::get_buffer()
     {
         commit();
+
         if (_buffers.size() == 1)
         {
             return _buffers[0];

--- a/src/dist/replication/lib/mutation.h
+++ b/src/dist/replication/lib/mutation.h
@@ -82,21 +82,15 @@ public:
 
     // >= 1 MB
     bool is_full() const { return _appro_data_bytes >= 1024 * 1024; }
-    
-    // general reader & writer
-    void write_to(binary_writer& writer) const;
-    static mutation_ptr read_from(binary_reader& reader, dsn_message_t from);
 
-    // write-to/read-from mutation log file, for better performance
+    // read & write mutation data
     //
-    // TODO(qinzuoyan): the optimization is to marshall code as int but not string,
-    // but this may cause problem, because log may be used by different program and
-    // the code map may change:
+    // "mutation_update.code" should be marshalled as string for cross-process compatiblity, because:
     //   - the private log may be transfered to other node with different program
     //   - the private/shared log may be replayed by different program when server restart
-    void write_to_log_file(std::function<void(const blob&)> inserter) const;
-    void write_to_log_file(binary_writer& writer) const;
-    static mutation_ptr read_from_log_file(binary_reader& reader, dsn_message_t from);
+    void write_to(std::function<void(const blob&)> inserter) const;
+    void write_to(binary_writer& writer, dsn_message_t to) const;
+    static mutation_ptr read_from(binary_reader& reader, dsn_message_t from);
 
     // data
     mutation_data  data;

--- a/src/dist/replication/lib/mutation_log.cpp
+++ b/src/dist/replication/lib/mutation_log.cpp
@@ -84,7 +84,7 @@ using namespace ::dsn::service;
     // write mutation to pending buffer
     mu->data.header.log_offset = _pending_write_start_offset + _pending_write->size();
     //printf("%lld: %lld\n", d, mu->data.header.log_offset);
-    mu->write_to_log_file([this](blob bb)
+    mu->write_to([this](blob bb)
     {
         _pending_write->add(bb);
     });
@@ -246,7 +246,7 @@ void mutation_log_shared::write_pending_mutations(bool release_lock)
     // write mutation to pending buffer
     mu->data.header.log_offset = _pending_write_start_offset + _pending_write->size();
     //printf("%lld: %lld\n", d, mu->data.header.log_offset);
-    mu->write_to_log_file([this](blob bb)
+    mu->write_to([this](blob bb)
     {
         _pending_write->add(bb);
     });
@@ -297,13 +297,13 @@ bool mutation_log_private::get_learn_state_in_memory(
     {
         for (auto& mu : *issued_mutations)
         {
-            mu->write_to_log_file(writer);
+            mu->write_to(writer, nullptr);
         }
     }
     
     for (auto& mu : pending_mutations)
     {
-        mu->write_to_log_file(writer);
+        mu->write_to(writer, nullptr);
     }
 
     return r;
@@ -862,7 +862,7 @@ std::pair<log_file_ptr, int64_t> mutation_log::mark_new_offset(size_t size, bool
         while (!reader->is_eof())
         {
             auto old_size = reader->get_remaining_size();
-            mutation_ptr mu = mutation::read_from_log_file(*reader, nullptr);
+            mutation_ptr mu = mutation::read_from(*reader, nullptr);
             dassert(nullptr != mu, "");
             mu->set_logged();
 

--- a/src/dist/replication/lib/replica_2pc.cpp
+++ b/src/dist/replication/lib/replica_2pc.cpp
@@ -171,7 +171,7 @@ void replica::send_prepare_message(
         rpc_write_stream writer(msg);
         marshall(writer, get_gpid(), DSF_THRIFT_BINARY);
         marshall(writer, rconfig, DSF_THRIFT_BINARY);
-        mu->write_to(writer);
+        mu->write_to(writer, msg);
     }
     
     mu->remote_tasks()[addr] = rpc::call(addr, msg,

--- a/src/dist/replication/lib/replica_learn.cpp
+++ b/src/dist/replication/lib/replica_learn.cpp
@@ -340,7 +340,7 @@ void replica::on_learn(dsn_message_t msg, const learn_request& request)
         {
             auto mu = _prepare_list->get_mutation_by_decree(d);
             dassert(mu != nullptr, "");
-            mu->write_to(writer);
+            mu->write_to(writer, nullptr);
             count++;
         }
         response.type = learn_type::LT_CACHE;
@@ -1056,7 +1056,7 @@ error_code replica::apply_learned_state_from_private_log(learn_state& state)
         binary_reader reader(state.meta);
         while (!reader.is_eof())
         {
-            auto mu = mutation::read_from_log_file(reader, nullptr);
+            auto mu = mutation::read_from(reader, nullptr);
             auto d = mu->data.header.decree;
             if (d <= plist.last_committed_decree())
                 continue;


### PR DESCRIPTION
improvement:
- write task_code as string to make it cross-process compatible
- directly append blob to message_ex to avoid unnecessary memory copy
