### PR TITLE
fix bug in http message parser; fix documentation

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -803,25 +803,24 @@ INPUT                  = main.md \
                          ../include/dsn/cpp/service_app.h \
                          ../include/dsn/cpp/task_helper.h \
                          ../include/dsn/cpp/zlocks.h \
-                         ../include/dsn/toollet/explorer.h \
-                         ../include/dsn/toollet/fault_injector.h \
-                         ../include/dsn/toollet/profiler.h \
-                         ../include/dsn/toollet/tracer.h \
-                         ../include/dsn/tool/fastrun.h \
-                         ../include/dsn/tool/nativerun.h \
-                         ../include/dsn/tool/simulator.h \
                          ../include/dsn/tool_api.h \
-                         ../include/dsn/internal/task_queue.h \
-                         ../include/dsn/internal/task_worker.h \
-                         ../include/dsn/internal/timer_service.h \
-                         ../include/dsn/internal/zlock_provider.h \
-                         ../include/dsn/internal/nfs.h \
-                         ../include/dsn/internal/network.h \
-                         ../include/dsn/internal/aio_provider.h \
-                         ../include/dsn/internal/env_provider.h \
-                         ../include/dsn/internal/logging_provider.h \
-                         ../include/dsn/internal/perf_counter.h \
-                         ../include/dsn/internal/task_spec.h
+                         ../include/dsn/tool-api/task_queue.h \
+                         ../include/dsn/tool-api/task_worker.h \
+                         ../include/dsn/tool-api/timer_service.h \
+                         ../include/dsn/tool-api/zlock_provider.h \
+                         ../include/dsn/tool-api/nfs.h \
+                         ../include/dsn/tool-api/network.h \
+                         ../include/dsn/tool-api/aio_provider.h \
+                         ../include/dsn/tool-api/env_provider.h \
+                         ../include/dsn/tool-api/logging_provider.h \
+                         ../include/dsn/tool-api/perf_counter.h \
+                         ../include/dsn/tool-api/task_spec.h \
+                         ../include/dsn/tool-api/task.h  \                         
+                         ../src/plugins/tools.common/fault_injector.h \
+                         ../src/plugins/tools.common/profiler.h \
+                         ../src/plugins/tools.common/tracer.h \
+                         ../src/plugins/tools.common/nativerun.h \
+                         ../src/plugins/tools.common/simulator.h
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/plugins/tools.common/http_message_parser.cpp
+++ b/src/plugins/tools.common/http_message_parser.cpp
@@ -345,7 +345,7 @@ http_message_parser::http_message_parser()
     {
         auto owner = static_cast<http_message_parser*>(parser->data);
         dassert(owner->_current_buffer.buffer() != nullptr, "the read buffer is not owning");
-        owner->_current_message->buffers[0].assign(owner->_current_buffer.buffer(), at - owner->_current_buffer.buffer_ptr(), length);
+        owner->_current_message->buffers.rbegin()->assign(owner->_current_buffer.buffer(), at - owner->_current_buffer.buffer_ptr(), length);
         owner->_current_message->header->body_length = length;
         owner->_received_messages.emplace(std::move(owner->_current_message));
         return 0;


### PR DESCRIPTION
After this is merged, you may try http://imzhenyu.github.io/rDSN/webstudio/setting.html by:
- [core] toollets = profiler in config.ini
- set `server` and `meta server` be the addresses of target server and the meta server to be monitored
- try the viz pages such as http://imzhenyu.github.io/rDSN/webstudio/cli.html 
