### PR TITLE
add options of log_private_batch_buffer_count and log_shared_force_flush

### DIFF
--- a/src/dist/replication/client_lib/replication_common.cpp
+++ b/src/dist/replication/client_lib/replication_common.cpp
@@ -74,7 +74,7 @@ replication_options::replication_options()
 
     log_private_file_size_mb = 32;
     log_private_batch_buffer_kb = 512;
-    log_private_force_flush = true;
+    log_private_batch_buffer_count = 512;
 
     log_shared_file_size_mb = 32;
     log_shared_batch_buffer_kb = 0;
@@ -284,11 +284,11 @@ void replication_options::initialize()
         log_private_batch_buffer_kb,
         "private log buffer size (KB) for batching incoming logs"
         );
-    log_private_force_flush =
-        dsn_config_get_value_bool("replication",
-        "log_private_force_flush",
-        log_private_force_flush,
-        "when write private log, whether to flush file after write done"
+    log_private_batch_buffer_count =
+        (int)dsn_config_get_value_uint64("replication",
+        "log_private_batch_buffer_count",
+        log_private_batch_buffer_count,
+        "private log buffer max item count for batching incoming logs"
         );
 
     log_shared_file_size_mb =

--- a/src/dist/replication/client_lib/replication_common.h
+++ b/src/dist/replication/client_lib/replication_common.h
@@ -87,7 +87,7 @@ public:
 
     int32_t log_private_file_size_mb;
     int32_t log_private_batch_buffer_kb;
-    bool    log_private_force_flush;
+    int32_t log_private_batch_buffer_count;
 
     int32_t log_shared_file_size_mb;
     int32_t log_shared_batch_buffer_kb;

--- a/src/dist/replication/lib/mutation_log.cpp
+++ b/src/dist/replication/lib/mutation_log.cpp
@@ -179,11 +179,13 @@ void mutation_log_shared::write_pending_mutations(bool release_lock)
 
                 dassert(hdr->length + sizeof(log_block_header) == sz, "");
 
-                // flush to ensure that there is no gap between share log and in-memory buffer
-                // so that we can get all mutations in learning process.
-                //
-                // FIXME : the file could have been closed
-                lf->flush();
+                if (_force_flush)
+                {
+                    // flush to ensure that shared log data synced to disk
+                    //
+                    // FIXME : the file could have been closed
+                    lf->flush();
+                }
             }
 
             // here we use _is_writing instead of _issued_write.expired() to check writing done,

--- a/src/dist/replication/lib/mutation_log.h
+++ b/src/dist/replication/lib/mutation_log.h
@@ -354,11 +354,13 @@ class mutation_log_shared : public mutation_log
 public:
     mutation_log_shared(
         const std::string& dir,
-        int32_t max_log_file_mb
+        int32_t max_log_file_mb,
+        bool force_flush
         ) : 
         mutation_log(dir, max_log_file_mb, dsn::gpid(), nullptr),
         _is_writing(false),
-        _pending_write_start_offset(0)
+        _pending_write_start_offset(0),
+        _force_flush(force_flush)
     {}
 
     virtual ::dsn::task_ptr append(mutation_ptr& mu,
@@ -388,6 +390,8 @@ private:
     int64_t                        _pending_write_start_offset;
     std::shared_ptr<callbacks>     _pending_write_callbacks;
     std::shared_ptr<mutations>     _pending_write_mutations;
+
+    bool                           _force_flush;
 };
 
 class mutation_log_private : public mutation_log
@@ -399,7 +403,7 @@ public:
         gpid gpid,
         replica* r,
         uint32_t batch_buffer_bytes,
-        uint32_t batch_buffer_max_count = 512
+        uint32_t batch_buffer_max_count
         ) : 
         mutation_log(dir, max_log_file_mb, gpid, r), 
         _batch_buffer_bytes(batch_buffer_bytes), 

--- a/src/dist/replication/lib/replica_init.cpp
+++ b/src/dist/replication/lib/replica_init.cpp
@@ -212,7 +212,8 @@ error_code replica::init_app_and_prepare_list(bool create_new)
                 _options->log_private_file_size_mb,
                 get_gpid(),
                 this,
-                _options->log_private_batch_buffer_kb * 1024
+                _options->log_private_batch_buffer_kb * 1024,
+                _options->log_private_batch_buffer_count
                 );
             ddebug("%s: plog_dir = %s", name(), log_dir.c_str());
 
@@ -333,7 +334,8 @@ error_code replica::init_app_and_prepare_list(bool create_new)
                 _options->log_private_file_size_mb,
                 get_gpid(),
                 this,
-                _options->log_private_batch_buffer_kb * 1024
+                _options->log_private_batch_buffer_kb * 1024,
+                _options->log_private_batch_buffer_count
                 );
             ddebug("%s: plog_dir = %s", name(), log_dir.c_str());
 

--- a/src/dist/replication/lib/replica_stub.cpp
+++ b/src/dist/replication/lib/replica_stub.cpp
@@ -154,7 +154,8 @@ void replica_stub::initialize(const replication_options& opts, bool clear/* = fa
 
     _log = new mutation_log_shared(
         _options.slog_dir,
-        _options.log_shared_file_size_mb
+        _options.log_shared_file_size_mb,
+        _options.log_shared_force_flush
         );
     ddebug("slog_dir = %s", _options.slog_dir.c_str());
 
@@ -305,7 +306,8 @@ void replica_stub::initialize(const replication_options& opts, bool clear/* = fa
         }
         _log = new mutation_log_shared(
             _options.slog_dir,
-            opts.log_shared_file_size_mb
+            _options.log_shared_file_size_mb,
+            _options.log_shared_force_flush
             );
         auto lerr = _log->open(nullptr, [this](error_code err) { this->handle_log_failure(err); });
         dassert(lerr == ERR_OK, "restart log service must succeed");

--- a/src/tests/dsn/mutation_log.cpp
+++ b/src/tests/dsn/mutation_log.cpp
@@ -302,7 +302,8 @@ TEST(replication, mutation_log)
         4,
         gpid,
         nullptr,
-        1024
+        1024,
+        512
         );
 
     auto err = mlog->open(nullptr, nullptr);
@@ -341,7 +342,8 @@ TEST(replication, mutation_log)
         4,
         gpid,
         nullptr,
-        1024
+        1024,
+        512
         );
 
     int mutation_index = -1;

--- a/src/tests/dsn/mutation_log_learn.cpp
+++ b/src/tests/dsn/mutation_log_learn.cpp
@@ -85,7 +85,7 @@ TEST(replication, mutation_log_learn)
 
         // writing logs
         time_tic = std::chrono::steady_clock::now();
-        mutation_log_ptr mlog = new mutation_log_private(logp, 32, gpid, nullptr, 4096);
+        mutation_log_ptr mlog = new mutation_log_private(logp, 32, gpid, nullptr, 4096, 512);
         mlog->open(nullptr, nullptr);
         for (auto& mu : mutations)
         {
@@ -105,7 +105,7 @@ TEST(replication, mutation_log_learn)
 
         // reading logs
         time_tic = std::chrono::steady_clock::now();
-        mlog = new mutation_log_private(logp, 1, gpid, nullptr, 1024);
+        mlog = new mutation_log_private(logp, 1, gpid, nullptr, 1024, 512);
         mlog->open([](mutation_ptr& mu)->bool{ return true; }, nullptr);
         time_toc = std::chrono::steady_clock::now();
         std::cout << "learn_point[" << lp << "]: read time(us): " << std::chrono::duration_cast<std::chrono::microseconds>(time_toc - time_tic).count() << std::endl;


### PR DESCRIPTION
Conflicts:
    src/dist/replication/lib/mutation_log.cpp
    src/tests/dsn/mutation_log_learn.cpp
