### PR TITLE
fix thread_hash assignment policy when partition_hash is also assigned

### DIFF
--- a/bin/dsn.templates/cpp/single/client.h.php
+++ b/bin/dsn.templates/cpp/single/client.h.php
@@ -26,7 +26,7 @@ public:
 <?php    if ($f->is_one_way()) {?>
     void <?=$f->name?>(
         const <?=$f->get_cpp_request_type_name()?>& args,
-        int thread_hash = 0,
+        int thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
         uint64_t partition_hash = 0,
         dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
@@ -39,7 +39,7 @@ public:
     std::pair< ::dsn::error_code, <?=$f->get_cpp_return_type()?>> <?=$f->name?>_sync(
         const <?=$f->get_cpp_request_type_name()?>& args,
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
-        int thread_hash = 0,
+        int thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
         uint64_t partition_hash = 0,
         dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
@@ -64,8 +64,8 @@ public:
         const <?=$f->get_cpp_request_type_name()?>& args,
         TCallback&& callback,
         std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
-        int thread_hash = 0,
-        uint64_t partition_hash = 0,
+        int request_thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+        uint64_t request_partition_hash = 0,
         int reply_thread_hash = 0,
         dsn::optional< ::dsn::rpc_address> server_addr = dsn::none
         )
@@ -77,8 +77,8 @@ public:
                     this,
                     std::forward<TCallback>(callback),
                     timeout,
-                    thread_hash,
-                    partition_hash,
+                    request_thread_hash,
+                    request_partition_hash,
                     reply_thread_hash
                     );
     }

--- a/bin/dsn.templates/csharp/layer3/client.cs.php
+++ b/bin/dsn.templates/csharp/layer3/client.cs.php
@@ -25,10 +25,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
 <?php    if ($f->is_one_way()) {?>
         public void <?=$f->name?>(
             <?=$f->get_csharp_request_type_name()?> args,
-            UInt64 hash = 0,
+            int thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, 0, hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, 0, thread_hash, partition_hash);
             s.Write(args);
             s.Flush();
             
@@ -40,10 +41,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
             <?=$f->get_csharp_request_type_name()?> args,
             out <?=$f->get_csharp_return_type()?> resp, 
             int timeout_milliseconds = 0, 
-            UInt64 hash = 0,
+            int thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, timeout_milliseconds, hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, timeout_milliseconds, thread_hash, partition_hash);
             s.Write(args);
             s.Flush();
             
@@ -67,10 +69,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
             <?=$f->name?>Callback callback,
             int timeout_milliseconds = 0, 
             int reply_thread_hash = 0,
-            UInt64 request_hash = 0,
+            int request_thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 request_partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, request_hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, request_thread_hash, request_partition_hash);
             s.Write(args);
             s.Flush();
             
@@ -93,10 +96,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
             <?=$f->name?>Callback callback,
             int timeout_milliseconds = 0, 
             int reply_thread_hash = 0,
-            UInt64 hash = 0,
+            int request_thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 request_partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, request_thread_hash, request_partition_hash);
             s.Write(args);
             s.Flush();
             

--- a/bin/dsn.templates/csharp/single/client.cs.php
+++ b/bin/dsn.templates/csharp/single/client.cs.php
@@ -25,10 +25,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
 <?php    if ($f->is_one_way()) {?>
         public void <?=$f->name?>(
             <?=$f->get_csharp_request_type_name()?> args,
-            UInt64 hash = 0,
+            int thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, 0, hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, 0, thread_hash, partition_hash);
             s.Write(args);
             s.Flush();
             
@@ -40,10 +41,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
             <?=$f->get_csharp_request_type_name()?> args,
             out <?=$f->get_csharp_return_type()?> resp, 
             int timeout_milliseconds = 0, 
-            UInt64 hash = 0,
+            int thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, timeout_milliseconds, hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>, timeout_milliseconds, thread_hash, partition_hash);
             s.Write(args);
             s.Flush();
             
@@ -67,10 +69,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
             <?=$f->name?>Callback callback,
             int timeout_milliseconds = 0, 
             int reply_thread_hash = 0,
-            UInt64 request_hash = 0,
+            int request_thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 request_partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, request_hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, request_thread_hash, request_partition_hash);
             s.Write(args);
             s.Flush();
             
@@ -93,10 +96,11 @@ namespace <?=$_PROG->get_csharp_namespace()?>
             <?=$f->name?>Callback callback,
             int timeout_milliseconds = 0, 
             int reply_thread_hash = 0,
-            UInt64 hash = 0,
+            int request_thread_hash = 0, // if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+            UInt64 request_partition_hash = 0,
             RpcAddress server = null)
         {
-            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, hash);
+            RpcWriteStream s = new RpcWriteStream(<?=$_PROG->name?>Helper.<?=$f->get_rpc_code()?>,timeout_milliseconds, request_thread_hash, request_partition_hash);
             s.Write(args);
             s.Flush();
             

--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -616,8 +616,9 @@ rpc message read/write
  \param rpc_code              task code for this request
  \param timeout_milliseconds  timeout for the RPC call, 0 for default value as 
                               configued in config files for the task code 
- \param hash                  used for both partition and thread hash to locate which thread
-   the request should be sent to
+ \param thread_hash           used for thread dispatching on server, 
+                              if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
+ \param partition_hash        used for finding which partition the request should be sent to
  \return RPC message handle
  */
 extern DSN_API dsn_message_t dsn_msg_create_request(
@@ -707,6 +708,7 @@ typedef struct dsn_msg_options_t
 {
     int               timeout_ms;     ///< RPC timeout in milliseconds
     int               thread_hash;    ///< thread hash on RPC server
+                                      ///< if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
     uint64_t          partition_hash; ///< partition hash for calculating partition index
     dsn_gpid          gpid;           ///< virtual node id, 0 for none
     dsn_msg_context_t context;        ///< see \ref dsn_msg_context_t

--- a/include/dsn/cpp/clientlet.h
+++ b/include/dsn/cpp/clientlet.h
@@ -301,7 +301,7 @@ namespace dsn
             clientlet* owner,
             TCallback&& callback,
             std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
-            int thread_hash = 0,
+            int thread_hash = 0, ///< if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
             uint64_t partition_hash = 0,
             int reply_thread_hash = 0
             )
@@ -333,7 +333,7 @@ namespace dsn
             dsn_task_code_t code,
             TRequest&& req,
             std::chrono::milliseconds timeout = std::chrono::milliseconds(0),
-            int thread_hash = 0,
+            int thread_hash = 0,///< if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
             uint64_t partition_hash = 0
             )
         {
@@ -358,7 +358,7 @@ namespace dsn
             ::dsn::rpc_address server,
             dsn_task_code_t code,
             const TRequest& req,
-            int thread_hash = 0,
+            int thread_hash = 0,///< if thread_hash == 0 && partition_hash != 0, thread_hash is computed from partition_hash
             uint64_t partition_hash = 0
             )
         {

--- a/src/core/src/rpc_engine.cpp
+++ b/src/core/src/rpc_engine.cpp
@@ -738,8 +738,6 @@ namespace dsn {
             // handle replication
             if (msg->header->gpid.value != 0)
             {
-                int thread_hash = dsn_gpid_to_thread_hash(msg->header->gpid);
-                dassert(msg->header->client.thread_hash == thread_hash, "inconsistent thread hash");
                 tsk = _node->generate_l2_rpc_request_task(msg);
             }
 
@@ -901,11 +899,11 @@ namespace dsn {
                         {
                             dassert(hdr2->gpid.value == 0, "inconsistent gpid");
                             hdr2->gpid = result.pid;
-                            int thread_hash = dsn_gpid_to_thread_hash(result.pid);
-                            if (hdr2->client.thread_hash != thread_hash)
+
+                            // update thread hash if not assigned by applications
+                            if (hdr2->client.thread_hash == 0)
                             {
-                                dassert(hdr2->client.thread_hash == 0, "inconsistent thread hash");
-                                hdr2->client.thread_hash = thread_hash;
+                                hdr2->client.thread_hash = dsn_gpid_to_thread_hash(result.pid);
                             }
                         }
 

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -401,6 +401,8 @@ message_ex* message_ex::create_request(dsn_task_code_t rpc_code, int timeout_mil
     hdr.hdr_length = sizeof(message_header);
     hdr.hdr_crc32 = hdr.body_crc32 = CRC_INVALID;
 
+    // if thread_hash == 0 && partition_hash != 0, 
+    // thread_hash is computed from partition_hash in rpc_engine
     hdr.client.thread_hash = thread_hash;
     hdr.client.partition_hash = partition_hash;
 

--- a/src/dev/csharp/NativeCalls.cs
+++ b/src/dev/csharp/NativeCalls.cs
@@ -625,7 +625,7 @@ namespace dsn.dev.csharp
         // and msg_release_ref explicitly.
         //
         [DllImport(DSN_CORE_DLL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern dsn_message_t dsn_msg_create_request(dsn_task_code_t rpc_code, int timeout_milliseconds, UInt64 hash);
+        public static extern dsn_message_t dsn_msg_create_request(dsn_task_code_t rpc_code, int timeout_milliseconds, Int32 thread_hash, UInt64 partition_hash);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern dsn_message_t dsn_msg_create_response(dsn_message_t request);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]

--- a/src/dev/csharp/RpcStream.cs
+++ b/src/dev/csharp/RpcStream.cs
@@ -130,8 +130,8 @@ namespace dsn.dev.csharp
 
     public class RpcWriteStream : RpcStream
     {
-        public RpcWriteStream(TaskCode code, int timeoutMilliseconds, ulong hash)
-            : base(Native.dsn_msg_create_request(code, timeoutMilliseconds, hash), false, false)
+        public RpcWriteStream(TaskCode code, int timeoutMilliseconds, int thread_hash, ulong partition_hash)
+            : base(Native.dsn_msg_create_request(code, timeoutMilliseconds, thread_hash, partition_hash), false, false)
         {
             _currentWriteOffset = 0;
             _currentBufferLength = IntPtr.Zero;

--- a/src/plugins/apps.echo.csharp/echo.client.cs
+++ b/src/plugins/apps.echo.csharp/echo.client.cs
@@ -14,10 +14,11 @@ namespace dsn.example
             string val, 
             out string resp, 
             int timeout_milliseconds = 0, 
-            ulong hash = 0,
+            int thread_hash = 0,
+            ulong partition_hash = 0,
             RpcAddress server = null)
         {
-            var s = new RpcWriteStream(echoHelper.RPC_ECHO_ECHO_PING, timeout_milliseconds, hash);
+            var s = new RpcWriteStream(echoHelper.RPC_ECHO_ECHO_PING, timeout_milliseconds, thread_hash, partition_hash);
             s.Write(val);
             s.Flush();
             
@@ -41,10 +42,11 @@ namespace dsn.example
             pingCallback callback,
             int timeout_milliseconds = 0, 
             int reply_thread_hash = 0,
-            ulong request_hash = 0,
+            int thread_hash = 0,
+            ulong partition_hash = 0,
             RpcAddress server = null)
         {
-            var s = new RpcWriteStream(echoHelper.RPC_ECHO_ECHO_PING, timeout_milliseconds, request_hash);
+            var s = new RpcWriteStream(echoHelper.RPC_ECHO_ECHO_PING, timeout_milliseconds, thread_hash, partition_hash);
             s.Write(val);
             s.Flush();
             
@@ -67,10 +69,11 @@ namespace dsn.example
             pingCallback callback,
             int timeout_milliseconds = 0, 
             int reply_thread_hash = 0,
-            ulong request_hash = 0,
+            int request_thread_hash = 0,
+            ulong request_partition_hash = 0,
             RpcAddress server = null)
         {
-            var s = new RpcWriteStream(echoHelper.RPC_ECHO_ECHO_PING, timeout_milliseconds, request_hash);
+            var s = new RpcWriteStream(echoHelper.RPC_ECHO_ECHO_PING, timeout_milliseconds, request_thread_hash, request_partition_hash);
             s.Write(val);
             s.Flush();
             


### PR DESCRIPTION
For applications to be partitioned, developers specify the partition_hash for the system to get the correspondent partition. The current implementation further use this partition_hash for getting the thread_hash for thread location to handle the request in frameworks (e.g., replication). However, this is only replication framework specific behavior and should not be implemented in core. We therefore change the way of computing thread-hash when partition-hash != 0:
- if thread_hash != 0, use user supplied thread_hash
- if thread_hash == 0, use dsn_gpid_to_thread_hash(gpid), where gpid is resolved from partition_hash
