### PR TITLE
remove useless _issued_write_task variable in mutation_log, which is …

### DIFF
--- a/src/plugins/dist.service/replica_server/replication_lib/mutation_log.cpp
+++ b/src/plugins/dist.service/replica_server/replication_lib/mutation_log.cpp
@@ -152,7 +152,7 @@ void mutation_log_shared::write_pending_mutations(bool release_lock)
     // seperate commit_log_block from within the lock
     _slock.unlock();
 
-    _issued_write_task = pr.first->commit_log_block(
+    pr.first->commit_log_block(
         *blk,
         soffset,
         LPC_WRITE_REPLICATION_LOG_SHARED,
@@ -346,7 +346,6 @@ void mutation_log_private::init_states()
 
     _is_writing.store(false, std::memory_order_release);
     _issued_write_mutations.reset();
-    _issued_write_task = nullptr;
     _pending_write_start_offset = 0;
     _pending_write = nullptr;
     _pending_write_mutations = nullptr;
@@ -378,7 +377,7 @@ void mutation_log_private::write_pending_mutations(bool release_lock)
     // seperate commit_log_block from within the lock
     _plock.unlock();
 
-    _issued_write_task = pr.first->commit_log_block(
+    pr.first->commit_log_block(
         *blk,
         soffset,
         LPC_WRITE_REPLICATION_LOG_PRIVATE,

--- a/src/plugins/dist.service/replica_server/replication_lib/mutation_log.h
+++ b/src/plugins/dist.service/replica_server/replication_lib/mutation_log.h
@@ -385,7 +385,6 @@ private:
     typedef std::vector<mutation_ptr> mutations;    
     mutable zlock                  _slock;
     std::atomic_bool               _is_writing;
-    task_ptr                       _issued_write_task; // for debugging
     std::shared_ptr<log_block>     _pending_write;
     int64_t                        _pending_write_start_offset;
     std::shared_ptr<callbacks>     _pending_write_callbacks;
@@ -441,7 +440,6 @@ private:
     typedef std::vector<mutation_ptr> mutations;
     std::atomic_bool               _is_writing;
     std::weak_ptr<mutations>       _issued_write_mutations;
-    task_ptr                       _issued_write_task; // for debugging
     int64_t                        _pending_write_start_offset;
     std::shared_ptr<log_block>     _pending_write;
     std::shared_ptr<mutations>     _pending_write_mutations;


### PR DESCRIPTION
…not protected by lock when assigning, refer to #520
