### PR TITLE
improve check of dmodule in config

### DIFF
--- a/src/plugins/apps.skv/config-backup-tool.ini
+++ b/src/plugins/apps.skv/config-backup-tool.ini
@@ -2,6 +2,7 @@
 dsn.tools.common
 dsn.tools.nfs
 dsn.dist.uri.resolver
+dsn.dist.service.meta_server
 
 [apps..default]
 run = true

--- a/src/plugins/apps.skv/config-docker.ini
+++ b/src/plugins/apps.skv/config-docker.ini
@@ -2,6 +2,9 @@
 dsn.tools.common
 dsn.tools.nfs
 dsn.dist.uri.resolver
+dsn.dist.service.meta_server
+dsn.dist.service.stateful.type1
+dsn.dev.python_helper
 
 [apps..default]
 run = true

--- a/src/plugins/apps.skv/config-zk.ini
+++ b/src/plugins/apps.skv/config-zk.ini
@@ -2,6 +2,8 @@
 dsn.tools.common
 dsn.tools.nfs
 dsn.dist.uri.resolver
+dsn.dist.service.meta_server
+dsn.dist.service.stateful.type1
 
 [apps..default]
 run = true

--- a/src/plugins/apps.skv/config.ini
+++ b/src/plugins/apps.skv/config.ini
@@ -2,6 +2,8 @@
 dsn.tools.common
 dsn.tools.nfs
 dsn.dist.uri.resolver
+dsn.dist.service.meta_server
+dsn.dist.service.stateful.type1
 
 [apps..default]
 run = true

--- a/src/plugins/apps.skv/perf-config.ini
+++ b/src/plugins/apps.skv/perf-config.ini
@@ -2,6 +2,8 @@
 dsn.tools.common
 dsn.tools.nfs
 dsn.dist.uri.resolver
+dsn.dist.service.meta_server
+dsn.dist.service.stateful.type1
 
 [apps..default]
 run = true

--- a/src/plugins/apps.skv/vconfig.ini
+++ b/src/plugins/apps.skv/vconfig.ini
@@ -2,6 +2,8 @@
 dsn.tools.common
 dsn.tools.nfs
 dsn.dist.uri.resolver
+dsn.dist.service.meta_server
+dsn.dist.service.stateful.type1
 
 [apps..default]
 run = true


### PR DESCRIPTION
- user must specify module in **[modules]** (even for modules in **[app.*].dmodule**), to determine the loading order of all modules.
- if "dmodule_bridge_arguments" is set in multiple places for a module, they should be the same. 
