### PR TITLE
- When STL containers are defined and used across dlls, memories may …

### DIFF
--- a/include/dsn/cpp/callocator.h
+++ b/include/dsn/cpp/callocator.h
@@ -36,6 +36,7 @@
 # pragma once
 
 # include <dsn/service_api_c.h>
+# include <memory>
 
 namespace dsn {
 
@@ -70,7 +71,7 @@ namespace dsn {
     typedef callocator_object<dsn_transient_malloc, dsn_transient_free> transient_object;
 
     template <typename T, t_allocate a, t_deallocate d>
-    class callocator
+    class callocator : public std::allocator<T>
     {
     public:
         typedef T value_type;
@@ -83,19 +84,20 @@ namespace dsn {
             typedef callocator<_Tp1, a, d> other;
         };
 
-        static T* allocate(size_type n)
+        T* allocate(size_type n, const void *hint = 0)
         {
             return static_cast<T*>(a(uint32_t(n * sizeof(T))));
         }
 
-        static void deallocate(T* p, size_type n)
+        void deallocate(T* p, size_type n)
         {
             d(p);
         }
 
-        callocator() throw()  {}
+        callocator() throw() : std::allocator<T>() {}
         template<typename U>
-        callocator(const callocator<U, a, d> &ac) throw(){ }
+        callocator(const callocator<U, a, d> &ac) throw() 
+            : std::allocator<T>(ac) { }
         ~callocator() throw() { }
     };
 

--- a/include/dsn/cpp/config_helper.h
+++ b/include/dsn/cpp/config_helper.h
@@ -56,7 +56,7 @@
     val.fld = (real_type)dsn_config_get_value_##config_type(section, #fld, default_value ? default_value->fld : default_fld_value, dsptr);
 
 # define CONFIG_FLD_STRING(fld, default_fld_value, dsptr) \
-    val.fld = dsn_config_get_value_string(section, #fld, (val.fld.length() > 0 && val.fld != std::string(default_fld_value)) ? \
+    val.fld = dsn_config_get_value_string(section, #fld, (val.fld.length() > 0 && val.fld != default_fld_value) ? \
          val.fld.c_str() : (default_value ? default_value->fld.c_str() : default_fld_value), dsptr);
 
 // customized_id<type> fld = xyz
@@ -123,6 +123,14 @@
 # define CONFIG_FLD_STRING_LIST(fld, dsptr) \
     {\
     std::string vv = dsn_config_get_value_string(section, #fld, "", dsptr); \
+    ::dsn::utils::split_args(vv.c_str(), val.fld, ','); \
+    if (val.fld.size() == 0 && default_value) \
+        val.fld = default_value->fld;\
+    }
+
+# define CONFIG_FLD_SAFE_STRING_LIST(fld, dsptr) \
+    {\
+    ::dsn::safe_string vv = dsn_config_get_value_string(section, #fld, "", dsptr); \
     ::dsn::utils::split_args(vv.c_str(), val.fld, ','); \
     if (val.fld.size() == 0 && default_value) \
         val.fld = default_value->fld;\

--- a/include/dsn/cpp/safe_string.h
+++ b/include/dsn/cpp/safe_string.h
@@ -35,13 +35,43 @@
 
 #pragma once
 
+# include <dsn/service_api_c.h>
+# include <dsn/cpp/callocator.h>
+# include <vector>
+# include <list>
 # include <cstring>
 # include <string>
-# include <dsn/service_api_c.h>
+# include <sstream>
+# include <map>
 
 namespace dsn
 {
-    class safe_string
+    template<typename T>
+    using safe_allocator = callocator<T, dsn_malloc, dsn_free>;
+
+    template <class T, class U>
+    bool operator==(const safe_allocator<T>&, const safe_allocator<U>&)
+    {
+        return true;
+    }
+    template <class T, class U>
+    bool operator!=(const safe_allocator<T>&, const safe_allocator<U>&)
+    {
+        return false;
+    }
+
+    template<typename T>
+    using safe_vector = ::std::vector<T, safe_allocator<T> >;
+
+    template<typename T>
+    using safe_list = ::std::list<T, safe_allocator<T> >;
+
+    using safe_string = ::std::basic_string<char, ::std::char_traits<char>, safe_allocator<char> >;
+
+    using safe_sstream = ::std::basic_stringstream<char, ::std::char_traits<char>,
+        safe_allocator<char> >;
+
+    /*class safe_string
     {
     public:
         safe_string()
@@ -158,5 +188,5 @@ namespace dsn
     private:
         char* _content;
         int   _length;
-    };
+    };*/
 }

--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -37,6 +37,7 @@
 
 # include <dsn/cpp/auto_codes.h>
 # include <dsn/cpp/callocator.h>
+# include <dsn/cpp/safe_string.h>
 # include <functional>
 
 # ifdef __TITLE__
@@ -110,7 +111,9 @@ namespace dsn {
     namespace utils {
 
         extern void split_args(const char* args, /*out*/ std::vector<std::string>& sargs, char splitter = ' ');
+        extern void split_args(const char* args, /*out*/ safe_vector<safe_string>& sargs, char splitter = ' ');
         extern void split_args(const char* args, /*out*/ std::list<std::string>& sargs, char splitter = ' ');
+        extern void split_args(const char* args, /*out*/ safe_list<safe_string>& sargs, char splitter = ' ');
         extern std::string replace_string(std::string subject, const std::string& search, const std::string& replace);
         extern std::string get_last_component(const std::string& input, const char splitters[]);
 

--- a/include/dsn/tool-api/command.h
+++ b/include/dsn/tool-api/command.h
@@ -42,10 +42,10 @@
 
 namespace dsn {
     
-    typedef std::function<std::string(const std::vector<std::string>&)> command_handler;
+    typedef std::function<safe_string(const safe_vector<safe_string>&)> command_handler;
 
     extern DSN_API void* register_command(
-        const std::vector<const char*>& commands, // commands, e.g., {"help", "Help", "HELP", "h", "H"}
+        const safe_vector<const char*>& commands, // commands, e.g., {"help", "Help", "HELP", "h", "H"}
         const char* help_one_line,
         const char* help_long,
         command_handler handler

--- a/include/dsn/tool-api/global_checker.h
+++ b/include/dsn/tool-api/global_checker.h
@@ -36,8 +36,7 @@
 # pragma once
 
 # include <dsn/service_api_c.h>
-# include <string>
-# include <vector>
+# include <dsn/cpp/safe_string.h>
 
 namespace dsn 
 {
@@ -58,13 +57,13 @@ namespace dsn
 
             virtual void check() = 0;
 
-            const std::string& name() const { return _name; }
+            const safe_string& name() const { return _name; }
 
         protected:
-            std::vector<dsn_app_info> _apps;
+            safe_vector<dsn_app_info> _apps;
 
         private:
-            std::string _name;
+            safe_string _name;
 
         public:
             template<typename T> // T : public checker

--- a/include/dsn/tool-api/global_checkers.h
+++ b/include/dsn/tool-api/global_checkers.h
@@ -38,15 +38,16 @@
 # include <list>
 # include <dsn/utility/dlib.h>
 # include <dsn/service_api_c.h>
+# include <dsn/cpp/safe_string.h>
 
 namespace dsn {
     
     struct global_checker
     {
-        std::string        name;
+        safe_string        name;
         dsn_checker_create create;
         dsn_checker_apply  apply;
     };
 
-    DSN_API void get_registered_checkers(/*out*/ std::list<global_checker>& checkers);
+    DSN_API void get_registered_checkers(/*out*/ safe_vector<global_checker>& checkers);
 }

--- a/include/dsn/tool-api/global_config.h
+++ b/include/dsn/tool-api/global_config.h
@@ -49,7 +49,7 @@ namespace dsn {
 //
 struct network_client_config
 {
-    std::string factory_name;
+    safe_string factory_name;
     int         message_buffer_block_size;
 
     DSN_API network_client_config();
@@ -64,7 +64,7 @@ struct network_server_config
     rpc_channel channel;
     // ]
 
-    std::string           factory_name;
+    safe_string           factory_name;
     int                   message_buffer_block_size;
 
     DSN_API network_server_config();
@@ -86,22 +86,22 @@ struct service_app_spec
 {
     int                  id;    // global id for all roles, assigned by rDSN automatically, also named as "app_id"
     int                  index; // local index for the current role (1,2,3,...), also named as "role_index"
-    std::string          data_dir; // data dir for the app. it is auto-set as ${service_spec.data_dir}/${service_app_spec.name}.
-    std::string          config_section; // [apps.${role_name}]
-    std::string          role_name;  // role name of [apps.${role_name}], also named as "app_name"
-    std::string          name;  // combined by role_name and role_index, also named as "app_full_name"
+    safe_string          data_dir; // data dir for the app. it is auto-set as ${service_spec.data_dir}/${service_app_spec.name}.
+    safe_string          config_section; // [apps.${role_name}]
+    safe_string          role_name;  // role name of [apps.${role_name}], also named as "app_name"
+    safe_string          name;  // combined by role_name and role_index, also named as "app_full_name"
                                 // e.g., if role_name = meta and role_index = 1, then app_full_name = meta1
                                 // specially, if role count is 1, then app_full_name equals to role_name
                                 // it is usually used for printing log
-    std::string          type;  // registered type name, alse named as "app_type"
-    std::string          arguments;
-    std::vector<int>     ports;
-    std::list<dsn_threadpool_code_t> pools;
+    safe_string          type;  // registered type name, alse named as "app_type"
+    safe_string          arguments;
+    safe_vector<int>     ports;
+    safe_list<dsn_threadpool_code_t> pools;
     int                  delay_seconds;
     bool                 run;
     int                  count; // index = 1,2,...,count
     int                  ports_gap; // when count > 1 or service_spec.io_mode != IOE_PER_NODE
-    std::string          dmodule; // when the service is a dynamcially loaded module
+    safe_string          dmodule; // when the service is a dynamcially loaded module
 
     //
     // when the service cannot automatically register its app types into rdsn 
@@ -110,7 +110,7 @@ struct service_app_spec
     // which loads the real target (e.g., a python/Java/php module), that registers their
     // app types and factories.
     //
-    std::string          dmodule_bridge_arguments; 
+    safe_string          dmodule_bridge_arguments; 
     dsn_app              *role;
 
     network_client_configs network_client_confs;
@@ -146,9 +146,9 @@ CONFIG_END
 
 struct service_spec
 {
-    std::string                  tool;   // the main tool (only 1 is allowed for a time)
-    std::list<std::string>       toollets; // toollets enabled compatible to the main tool
-    std::string                  data_dir; // to store all data/log/coredump etc.
+    safe_string                  tool;   // the main tool (only 1 is allowed for a time)
+    safe_list<safe_string>       toollets; // toollets enabled compatible to the main tool
+    safe_string                  data_dir; // to store all data/log/coredump etc.
     bool                         start_nfs;
 
     //
@@ -164,27 +164,27 @@ struct service_spec
     //
     bool                         enable_default_app_mimic;
     
-    std::string                  timer_factory_name;
-    std::string                  aio_factory_name;
-    std::string                  env_factory_name;
-    std::string                  lock_factory_name;
-    std::string                  lock_nr_factory_name;
-    std::string                  rwlock_nr_factory_name;
-    std::string                  semaphore_factory_name;
-    std::string                  nfs_factory_name;
-    std::string                  perf_counter_factory_name;
-    std::string                  logging_factory_name;
-    std::string                  memory_factory_name; // for upper applications
-    std::string                  tools_memory_factory_name; // for rDSN itself and lower tools
+    safe_string                  timer_factory_name;
+    safe_string                  aio_factory_name;
+    safe_string                  env_factory_name;
+    safe_string                  lock_factory_name;
+    safe_string                  lock_nr_factory_name;
+    safe_string                  rwlock_nr_factory_name;
+    safe_string                  semaphore_factory_name;
+    safe_string                  nfs_factory_name;
+    safe_string                  perf_counter_factory_name;
+    safe_string                  logging_factory_name;
+    safe_string                  memory_factory_name; // for upper applications
+    safe_string                  tools_memory_factory_name; // for rDSN itself and lower tools
 
-    std::list<std::string>       network_aspects; // toollets compatible to the above network main providers in network configs
-    std::list<std::string>       aio_aspects; // toollets compatible to main aio provider
-    std::list<std::string>       env_aspects;
-    std::list<std::string>       timer_aspects;
-    std::list<std::string>       lock_aspects;
-    std::list<std::string>       lock_nr_aspects;
-    std::list<std::string>       rwlock_nr_aspects;
-    std::list<std::string>       semaphore_aspects;
+    safe_list<safe_string>       network_aspects; // toollets compatible to the above network main providers in network configs
+    safe_list<safe_string>       aio_aspects; // toollets compatible to main aio provider
+    safe_list<safe_string>       env_aspects;
+    safe_list<safe_string>       timer_aspects;
+    safe_list<safe_string>       lock_aspects;
+    safe_list<safe_string>       lock_nr_aspects;
+    safe_list<safe_string>       rwlock_nr_aspects;
+    safe_list<safe_string>       semaphore_aspects;
 
     ioe_mode                     disk_io_mode; // whether disk is per node or per queue
     ioe_mode                     rpc_io_mode; // whether rpc is per node or per queue
@@ -194,12 +194,12 @@ struct service_spec
         
     network_client_configs        network_default_client_cfs; // default network configed by tools
     network_server_configs        network_default_server_cfs; // default network configed by tools
-    std::vector<threadpool_spec>  threadpool_specs;
-    std::vector<service_app_spec> app_specs;
+    safe_vector<threadpool_spec>  threadpool_specs;
+    safe_vector<service_app_spec> app_specs;
 
     // auto-set
-    std::string                   dir_coredump;
-    std::string                   dir_log;
+    safe_string                   dir_coredump;
+    safe_string                   dir_log;
 
     service_spec() {}
     bool init();

--- a/include/dsn/tool-api/message_parser.h
+++ b/include/dsn/tool-api/message_parser.h
@@ -134,6 +134,6 @@ namespace dsn
 
     public:
         DSN_API static network_header_format get_header_type(const char* bytes); // buffer size >= sizeof(uint32_t)
-        DSN_API static std::string get_debug_string(const char* bytes);
+        DSN_API static safe_string get_debug_string(const char* bytes);
     };
 }

--- a/include/dsn/tool-api/nfs.h
+++ b/include/dsn/tool-api/nfs.h
@@ -50,9 +50,9 @@ namespace dsn {
     struct remote_copy_request
     {
         ::dsn::rpc_address   source;
-        std::string source_dir;
-        std::vector<std::string> files;
-        std::string dest_dir;
+        safe_string source_dir;
+        safe_vector<safe_string> files;
+        safe_string dest_dir;
         bool        overwrite;
     };
 

--- a/include/dsn/tool-api/partition_resolver.h
+++ b/include/dsn/tool-api/partition_resolver.h
@@ -109,12 +109,12 @@ namespace dsn
 
             virtual int get_partition_index(int partition_count, uint64_t partition_hash) = 0;
 
-            std::string get_app_path() const { return _app_path; }
+            safe_string get_app_path() const { return _app_path; }
 
             ::dsn::rpc_address get_meta_server() const { return _meta_server; }
 
         protected:
-            std::string _app_path;
+            safe_string _app_path;
             rpc_address _meta_server;
         };
 

--- a/include/dsn/tool-api/rpc_message.h
+++ b/include/dsn/tool-api/rpc_message.h
@@ -43,6 +43,7 @@
 # include <dsn/cpp/auto_codes.h>
 # include <dsn/cpp/address.h>
 # include <dsn/cpp/blob.h>
+# include <dsn/cpp/safe_string.h>
 # include <dsn/utility/link.h>
 # include <dsn/tool-api/global_config.h>
 
@@ -105,7 +106,7 @@ namespace dsn
     {
     public:
         message_header         *header;
-        std::vector<blob>      buffers; // header included for *send* message, 
+        safe_vector<blob>      buffers; // header included for *send* message, 
                                         // header not included for *recieved*
 
         // by rpc and network

--- a/include/dsn/tool-api/task.h
+++ b/include/dsn/tool-api/task.h
@@ -247,7 +247,7 @@ private:
 struct rpc_handler_info
 {
     dsn_task_code_t           code;
-    std::string               name;
+    safe_string               name;
     bool                      unregistered;
     std::atomic<int>          running_count;
     dsn_rpc_request_handler_t c_handler;

--- a/include/dsn/tool-api/task_queue.h
+++ b/include/dsn/tool-api/task_queue.h
@@ -76,7 +76,7 @@ public:
     int               count() const { return _queue_length.load(std::memory_order_relaxed); }
     int               decrease_count(int count = 1) { _queue_length_counter->add((uint64_t)(-count));  return _queue_length.fetch_sub(count, std::memory_order_relaxed) - count;}
     int               increase_count(int count = 1) { _queue_length_counter->add(count);  return _queue_length.fetch_add(count, std::memory_order_relaxed) + count;}
-    const std::string & get_name() { return _name; }    
+    const safe_string & get_name() { return _name; }    
     task_worker_pool* pool() const { return _pool; }
     bool              is_shared() const { return _worker_count > 1; }
     int               worker_count() const { return _worker_count; }
@@ -95,7 +95,7 @@ private:
 private:
     task_worker_pool*      _pool;
     task_worker*           _owner_worker;
-    std::string            _name;
+    safe_string            _name;
     int                    _index;
     admission_controller*  _controller;
     int                    _worker_count;

--- a/include/dsn/tool-api/task_spec.h
+++ b/include/dsn/tool-api/task_spec.h
@@ -38,6 +38,7 @@
 # include <dsn/service_api_c.h>
 # include <dsn/cpp/utils.h>
 # include <dsn/cpp/config_helper.h>
+# include <dsn/cpp/safe_string.h>
 # include <dsn/utility/enum_helper.h>
 # include <dsn/utility/customizable_id.h>
 # include <dsn/utility/singleton_vector_store.h>
@@ -198,7 +199,7 @@ public:
     // not configurable [
     dsn_task_code_t        code;
     dsn_task_type_t        type;
-    std::string            name;    
+    safe_string            name;    
     dsn_task_code_t        rpc_paired_code;
     shared_exp_delay       rpc_request_delayer;
     // ]
@@ -221,7 +222,7 @@ public:
     int32_t                rpc_timeout_milliseconds;
     int32_t                rpc_request_resend_timeout_milliseconds; // 0 for no auto-resend
     throttling_mode_t      rpc_request_throttling_mode; // 
-    std::vector<int>       rpc_request_delays_milliseconds; // see exp_delay for delaying recving
+    safe_vector<int>       rpc_request_delays_milliseconds; // see exp_delay for delaying recving
     bool                   rpc_request_dropped_before_execution_when_timeout;
 
     // layer 2 configurations
@@ -301,7 +302,7 @@ CONFIG_END
 
 struct threadpool_spec
 {
-    std::string             name;
+    safe_string             name;
     dsn_threadpool_code_t   pool_code;
     int                     worker_count;
     worker_priority_t       worker_priority;
@@ -309,20 +310,20 @@ struct threadpool_spec
     uint64_t                worker_affinity_mask;
     int                     dequeue_batch_size;
     bool                    partitioned;         // false by default
-    std::string             queue_factory_name;
-    std::string             worker_factory_name;
-    std::list<std::string>  queue_aspects;
-    std::list<std::string>  worker_aspects;
+    safe_string             queue_factory_name;
+    safe_string             worker_factory_name;
+    safe_list<safe_string>  queue_aspects;
+    safe_list<safe_string>  worker_aspects;
     int                     queue_length_throttling_threshold;
     bool                    enable_virtual_queue_throttling;
-    std::string             admission_controller_factory_name;
-    std::string             admission_controller_arguments;
+    safe_string             admission_controller_factory_name;
+    safe_string             admission_controller_arguments;
 
     threadpool_spec(const dsn_threadpool_code_t& code) : name(dsn_threadpool_code_to_string(code)), pool_code(code) {}
     threadpool_spec(const threadpool_spec& source) = default;
     threadpool_spec& operator=(const threadpool_spec& source) = default;
 
-    DSN_API static bool init(/*out*/ std::vector<threadpool_spec>& specs);
+    DSN_API static bool init(/*out*/ safe_vector<threadpool_spec>& specs);
 };
 
 CONFIG_BEGIN(threadpool_spec)

--- a/include/dsn/tool-api/task_worker.h
+++ b/include/dsn/tool-api/task_worker.h
@@ -72,7 +72,7 @@ public:
     DSN_API virtual void loop(); // run tasks from _input_queue
 
     // inquery
-    const std::string& name() const { return _name; }
+    const safe_string& name() const { return _name; }
     int index() const { return _index; }
     int native_tid() const { return _native_tid; }
     task_worker_pool* pool() const { return _owner_pool; }
@@ -85,7 +85,7 @@ private:
     task_queue*       _input_queue;
     int               _index;
     int               _native_tid;
-    std::string       _name;
+    safe_string       _name;
     std::thread      *_thread;
     bool             _is_running;
     utils::notify_event _started;

--- a/src/core/src/command_manager.h
+++ b/src/core/src/command_manager.h
@@ -48,9 +48,9 @@ namespace dsn {
     public:
         command_manager();
 
-        dsn_handle_t register_command(const std::vector<const char*>& commands, const char* help_one_line, const char* help_long, command_handler handler);
+        dsn_handle_t register_command(const safe_vector<const char*>& commands, const char* help_one_line, const char* help_long, command_handler handler);
         void deregister_command(dsn_handle_t handle);
-        bool run_command(const std::string& cmdline, /*out*/ std::string& output);
+        bool run_command(const safe_string& cmdline, /*out*/ safe_string& output);
         void run_console();
         void start_local_cli();
         void start_remote_cli();
@@ -58,20 +58,20 @@ namespace dsn {
         void set_cli_target_address(dsn_handle_t handle, dsn::rpc_address address);
 
     private:
-        bool run_command(const std::string& cmd, const std::vector<std::string>& args, /*out*/ std::string& output);
+        bool run_command(const safe_string& cmd, const safe_vector<safe_string>& args, /*out*/ safe_string& output);
 
     private:
         struct command
         {
             dsn::rpc_address address;
-            std::vector<const char*> commands;
+            safe_vector<const char*> commands;
             std::string     help_short;
             std::string     help_long;
             command_handler handler;
         };
 
         ::dsn::utils::rw_lock_nr        _lock;
-        std::map<std::string, command*> _handlers;
+        std::map<safe_string, command*> _handlers;
         std::vector<command*>           _commands;
     };
 

--- a/src/core/src/command_manager.test.cpp
+++ b/src/core/src/command_manager.test.cpp
@@ -44,9 +44,9 @@ void command_manager_module_init()
     register_command("test-cmd",
         "test-cmd - just for command_manager unit-test",
         "test-cmd arg1 arg2 ...",
-        [](const std::vector<std::string>& args)
+        [](const safe_vector<safe_string>& args)
         {
-            std::stringstream ss;
+            safe_sstream ss;
             ss << "test-cmd response: [";
             for (size_t i = 0; i < args.size(); ++i)
             {

--- a/src/core/src/global_checkers.cpp
+++ b/src/core/src/global_checkers.cpp
@@ -42,10 +42,10 @@ namespace dsn
     class global_checker_store : public ::dsn::utils::singleton< global_checker_store >
     {
     public:
-        std::list<global_checker> checkers;
+        safe_vector<global_checker> checkers;
     };
 
-    void get_registered_checkers(/*out*/ std::list<global_checker>& checkers)
+    void get_registered_checkers(/*out*/ safe_vector<global_checker>& checkers)
     {
         checkers = ::dsn::global_checker_store::instance().checkers;
     }

--- a/src/core/src/global_config.cpp
+++ b/src/core/src/global_config.cpp
@@ -132,7 +132,7 @@ static bool build_server_network_confs(
     const char* section,
     /*out*/ network_server_configs& nss,
     network_server_configs* default_spec,
-    const std::vector<int>& ports,
+    const safe_vector<int>& ports,
     bool is_template)
 {
     nss.clear();
@@ -286,9 +286,9 @@ bool service_app_spec::init(
 {
     id = 0;
     index = 0;
-    role_name = std::string(role_name_);
+    role_name = role_name_;
     name = role_name;
-    config_section = std::string(section);
+    config_section = section;
 
     if (!read_config(section, *this, default_value))
         return false;
@@ -461,7 +461,7 @@ bool service_spec::init_app_specs()
 
             auto& store = ::dsn::utils::singleton_store<std::string, dsn_app*>::instance();
             dsn_app* role;
-            if (!store.get(app.type, role))
+            if (!store.get(app.type.c_str(), role))
             {
                 printf("service type '%s' not registered\n", app.type.c_str());
                 return false;
@@ -478,7 +478,7 @@ bool service_spec::init_app_specs()
                 app.name = (app.count > 1 ? (app.role_name + buf) : app.role_name);
                 app.id = ++app_id;
                 app.index = i;
-                app.data_dir = utils::filesystem::path_combine(data_dir, app.name);
+                app.data_dir = utils::filesystem::path_combine(data_dir.c_str(), app.name.c_str()).c_str();
 
                 // add app
                 app_specs.push_back(app);

--- a/src/core/src/lpc.test.cpp
+++ b/src/core/src/lpc.test.cpp
@@ -41,7 +41,7 @@
 void on_lpc_test(void* p)
 {
     std::string& result = *(std::string*)p;
-    result = ::dsn::task::get_current_worker()->name();
+    result = ::dsn::task::get_current_worker()->name().c_str();
 }
 
 void on_lpc_test2(void* p)

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -323,10 +323,10 @@ bool run(const char* config_file, const char* config_arguments, bool sleep_after
 
     // setup data dir
     auto& data_dir = spec.data_dir;
-    dassert(!dsn::utils::filesystem::file_exists(data_dir), "%s should not be a file.", data_dir.c_str());
+    dassert(!dsn::utils::filesystem::file_exists(data_dir.c_str()), "%s should not be a file.", data_dir.c_str());
     if (!dsn::utils::filesystem::directory_exists(data_dir.c_str()))
     {
-        if (!dsn::utils::filesystem::create_directory(data_dir))
+        if (!dsn::utils::filesystem::create_directory(data_dir.c_str()))
         {
             dassert(false, "Fail to create %s.", data_dir.c_str());
         }
@@ -336,16 +336,16 @@ bool run(const char* config_file, const char* config_arguments, bool sleep_after
     {
         dassert(false, "Fail to get absolute path from %s.", data_dir.c_str());
     }
-    spec.data_dir = cdir;
+    spec.data_dir = cdir.c_str();
 
     // setup coredump dir
-    spec.dir_coredump = ::dsn::utils::filesystem::path_combine(cdir, "coredumps");
-    dsn::utils::filesystem::create_directory(spec.dir_coredump);
+    spec.dir_coredump = ::dsn::utils::filesystem::path_combine(cdir, "coredumps").c_str();
+    dsn::utils::filesystem::create_directory(spec.dir_coredump.c_str());
     ::dsn::utils::coredump::init(spec.dir_coredump.c_str());
 
     // setup log dir
-    spec.dir_log = ::dsn::utils::filesystem::path_combine(cdir, "logs");
-    dsn::utils::filesystem::create_directory(spec.dir_log);
+    spec.dir_log = ::dsn::utils::filesystem::path_combine(cdir, "logs").c_str();
+    dsn::utils::filesystem::create_directory(spec.dir_log.c_str());
     
     // init tools
     dsn_all.tool = ::dsn::utils::factory_store< ::dsn::tools::tool_app>::create(spec.tool.c_str(), ::dsn::PROVIDER_TYPE_MAIN, spec.tool.c_str());
@@ -412,14 +412,14 @@ bool run(const char* config_file, const char* config_arguments, bool sleep_after
         {
             for (auto &kv : applistkvs)
             {
-                std::list<std::string> argskvs;
+                ::dsn::safe_list< ::dsn::safe_string> argskvs;
                 ::dsn::utils::split_args(kv.c_str(), argskvs, '@');
-                if (std::string("apps.") + argskvs.front() == sp.config_section)
+                if (::dsn::safe_string("apps.") + argskvs.front() == sp.config_section)
                 {
                     if (argskvs.size() < 2)
                         create_it = true;
                     else
-                        create_it = (std::stoi(argskvs.back()) == sp.index);
+                        create_it = (std::stoi(argskvs.back().c_str()) == sp.index);
                     break;
                 }
             }
@@ -448,14 +448,14 @@ bool run(const char* config_file, const char* config_arguments, bool sleep_after
     ::dsn::register_command("config-dump",
         "config-dump - dump configuration",
         "config-dump [to-this-config-file]",
-        [](const std::vector<std::string>& args)
+        [](const ::dsn::safe_vector< ::dsn::safe_string>& args)
     {
-        std::ostringstream oss;
+        ::dsn::safe_sstream oss;
         std::ofstream off;
         std::ostream* os = &oss;
         if (args.size() > 0)
         {
-            off.open(args[0]);
+            off.open(args[0].c_str());
             os = &off;
 
             oss << "config dump to file " << args[0] << std::endl;

--- a/src/core/src/message_parser.cpp
+++ b/src/core/src/message_parser.cpp
@@ -154,10 +154,10 @@ namespace dsn {
         return header_type::header_type_to_c_type(ht);
     }
 
-    /*static*/ std::string message_parser::get_debug_string(const char* bytes)
+    /*static*/ safe_string message_parser::get_debug_string(const char* bytes)
     {
         header_type ht(bytes);
-        return ht.debug_string();
+        return ht.debug_string().c_str();
     }
 
     //-------------------- msg reader --------------------

--- a/src/core/src/perf_counters.cpp
+++ b/src/core/src/perf_counters.cpp
@@ -268,7 +268,7 @@ void perf_counters::register_factory(perf_counter::factory factory)
 }
 
 
-std::string perf_counters::list_counter(const std::vector<std::string>& args)
+safe_string perf_counters::list_counter(const safe_vector<safe_string>& args)
 {
     return perf_counters::instance().list_counter_internal(args);
 }
@@ -297,7 +297,7 @@ struct sample_resp {
     DEFINE_JSON_SERIALIZATION(val, time, counter_name, counter_index)
 };
 
-std::string perf_counters::list_counter_internal(const std::vector<std::string>& args)
+safe_string perf_counters::list_counter_internal(const safe_vector<safe_string>& args)
 {
     // <app, <section, counter_info[] > > counters
     std::map<std::string, std::map< std::string, std::vector<counter_info> > > counters;
@@ -331,10 +331,10 @@ std::string perf_counters::list_counter_internal(const std::vector<std::string>&
 
     std::stringstream ss;
     dsn::json::json_encode(ss, counters);
-    return ss.str();
+    return ss.str().c_str();
 }
 
-std::string perf_counters::get_counter_value(const std::vector<std::string>& args)
+safe_string perf_counters::get_counter_value(const safe_vector<safe_string>& args)
 {
     std::stringstream ss;
 
@@ -345,7 +345,7 @@ std::string perf_counters::get_counter_value(const std::vector<std::string>& arg
     if (args.size() < 1)
     {
         value_resp{ value, ts, std::string(), 0 }.encode_json_state(ss);
-        return ss.str();
+        return ss.str().c_str();
     }
 
     perf_counters& c = perf_counters::instance();
@@ -358,12 +358,12 @@ std::string perf_counters::get_counter_value(const std::vector<std::string>& arg
             value = counter->get_value();
     }
         
-    value_resp{ value, ts, args[0], counter_index }.encode_json_state(ss);
-    return ss.str();
+    value_resp{ value, ts, args[0].c_str(), counter_index }.encode_json_state(ss);
+    return ss.str().c_str();
 }
 
 
-std::string perf_counters::get_counter_sample(const std::vector<std::string>& args)
+safe_string perf_counters::get_counter_sample(const safe_vector<safe_string>& args)
 {
     std::stringstream ss;
 
@@ -374,7 +374,7 @@ std::string perf_counters::get_counter_sample(const std::vector<std::string>& ar
     if (args.size() < 1)
     {
         sample_resp{ sample, ts, std::string(), 0 }.encode_json_state(ss);
-        return ss.str();
+        return ss.str().c_str();
     }
 
     perf_counters& c = perf_counters::instance();
@@ -385,12 +385,12 @@ std::string perf_counters::get_counter_sample(const std::vector<std::string>& ar
         sample = counter->get_latest_sample();
         counter_index = counter->index();
     }
-    sample_resp{ sample, ts, args[0], counter_index }.encode_json_state(ss);
-    return ss.str();
+    sample_resp{ sample, ts, args[0].c_str(), counter_index }.encode_json_state(ss);
+    return ss.str().c_str();
 }
 
 
-std::string perf_counters::get_counter_value_i(const std::vector<std::string>& args)
+safe_string perf_counters::get_counter_value_i(const safe_vector<safe_string>& args)
 {
     std::stringstream ss;
 
@@ -401,7 +401,7 @@ std::string perf_counters::get_counter_value_i(const std::vector<std::string>& a
     if (args.size() < 1)
     {
         value_resp{ value, ts, std::string(), 0 }.encode_json_state(ss);
-        return ss.str();
+        return ss.str().c_str();
     }
 
     uint64_t idx = atoll(args[0].c_str());
@@ -417,11 +417,11 @@ std::string perf_counters::get_counter_value_i(const std::vector<std::string>& a
     }
     
     value_resp{ value, ts, counter_name, idx }.encode_json_state(ss);
-    return ss.str();
+    return ss.str().c_str();
 }
 
 
-std::string perf_counters::get_counter_sample_i(const std::vector<std::string>& args)
+safe_string perf_counters::get_counter_sample_i(const safe_vector<safe_string>& args)
 {
     std::stringstream ss;
 
@@ -432,7 +432,7 @@ std::string perf_counters::get_counter_sample_i(const std::vector<std::string>& 
     if (args.size() < 1)
     {
         sample_resp{ sample, ts, std::string(), 0 }.encode_json_state(ss);
-        return ss.str();
+        return ss.str().c_str();
     }
 
     uint64_t idx = atoll(args[0].c_str());
@@ -446,10 +446,10 @@ std::string perf_counters::get_counter_sample_i(const std::vector<std::string>& 
         counter_name = std::string(counter->full_name());
     }
     sample_resp{ sample, ts, counter_name, idx }.encode_json_state(ss);
-    return ss.str();
+    return ss.str().c_str();
 }
 
-std::string perf_counters::get_counter_index(const std::vector<std::string>& args)
+safe_string perf_counters::get_counter_index(const safe_vector<safe_string>& args)
 {
     std::stringstream ss;
 
@@ -466,7 +466,7 @@ std::string perf_counters::get_counter_index(const std::vector<std::string>& arg
     }
     
     dsn::json::json_encode(ss, counter_index_list);
-    return ss.str();
+    return ss.str().c_str();
 }
 
 } // end namespace

--- a/src/core/src/perf_counters.h
+++ b/src/core/src/perf_counters.h
@@ -66,17 +66,17 @@ public:
     bool remove_counter(const char* full_name);
     
     void register_factory(perf_counter::factory factory);
-    static std::string list_counter(const std::vector<std::string>& args);
-    static std::string get_counter_value(const std::vector<std::string>& args);
-    static std::string get_counter_sample(const std::vector<std::string>& args);
-    static std::string get_counter_value_i(const std::vector<std::string>& args);
-    static std::string get_counter_sample_i(const std::vector<std::string>& args);
-    static std::string get_counter_index(const std::vector<std::string>& args);
+    static safe_string list_counter(const safe_vector<safe_string>& args);
+    static safe_string get_counter_value(const safe_vector<safe_string>& args);
+    static safe_string get_counter_sample(const safe_vector<safe_string>& args);
+    static safe_string get_counter_value_i(const safe_vector<safe_string>& args);
+    static safe_string get_counter_sample_i(const safe_vector<safe_string>& args);
+    static safe_string get_counter_index(const safe_vector<safe_string>& args);
 
     typedef std::map<std::string, perf_counter_ptr > all_counters;
 
 private:
-    std::string list_counter_internal(const std::vector<std::string>& args);
+    safe_string list_counter_internal(const safe_vector<safe_string>& args);
     mutable utils::rw_lock_nr  _lock;
     all_counters               _counters;
     perf_counter::factory      _factory;

--- a/src/core/src/rpc_engine.cpp
+++ b/src/core/src/rpc_engine.cpp
@@ -411,11 +411,11 @@ namespace dsn {
 
         utils::auto_write_lock l(_handlers_lock);
         auto it = _handlers.find(name);
-        auto it2 = _handlers.find(handler->name);
+        auto it2 = _handlers.find(handler->name.c_str());
         if (it == _handlers.end() && it2 == _handlers.end())
         {
             _handlers[name] = handler;
-            _handlers[handler->name] = handler;   
+            _handlers[handler->name.c_str()] = handler;   
 
             {
                 utils::auto_write_lock l(_vhandlers[handler->code]->second);
@@ -440,9 +440,9 @@ namespace dsn {
                 return nullptr;
 
             ret = it->second;
-            std::string name = it->second->name;
+            auto name = it->second->name;
             _handlers.erase(it);
-            _handlers.erase(name);
+            _handlers.erase(name.c_str());
 
             {
                 utils::auto_write_lock l(_vhandlers[rpc_code]->second);
@@ -604,7 +604,7 @@ namespace dsn {
                 auto it1 = aspec.network_client_confs.find(c);
                 if (it1 != aspec.network_client_confs.end())
                 {
-                    factory = it1->second.factory_name;
+                    factory = it1->second.factory_name.c_str();
                     blk_size = it1->second.message_buffer_block_size;
                 }
                 else
@@ -614,7 +614,7 @@ namespace dsn {
                 }
 
                 network_server_config cs(aspec.id, c);
-                cs.factory_name = factory;
+                cs.factory_name = factory.c_str();
                 cs.message_buffer_block_size = blk_size;
 
                 auto net = create_network(cs, true, client_hdr_format, ctx);

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -550,7 +550,7 @@ DSN_API bool dsn_rpc_register_handler(
     )
 {
     ::dsn::rpc_handler_info* h(new ::dsn::rpc_handler_info(code));
-    h->name = std::string(name);
+    h->name = name;
     h->c_handler = cb;
     h->parameter = param;
 
@@ -791,7 +791,7 @@ DSN_API void dsn_file_copy_remote_files(dsn_address_t remote, const char* source
     const char** p = source_files;
     while (*p != nullptr && **p != '\0')
     {
-        rci->files.push_back(std::string(*p));
+        rci->files.push_back(*p);
         p++;
 
         dinfo("copy remote file %s from %s", 
@@ -928,8 +928,8 @@ DSN_API bool dsn_mimic_app(const char* app_name, int index)
     auto cnode = ::dsn::task::get_current_node2();
     if (cnode != nullptr)
     {
-        const std::string& name = cnode->spec().name;
-        if (cnode->spec().role_name == std::string(app_name)
+        const auto& name = cnode->spec().name;
+        if (cnode->spec().role_name == ::dsn::safe_string(app_name)
             && cnode->spec().index == index)
         {
             return true;
@@ -944,7 +944,7 @@ DSN_API bool dsn_mimic_app(const char* app_name, int index)
     auto nodes = ::dsn::service_engine::instance().get_all_nodes();
     for (auto& n : nodes)
     {
-        if (n.second->spec().role_name == std::string(app_name)
+        if (n.second->spec().role_name == ::dsn::safe_string(app_name)
             && n.second->spec().index == index)
         {
             ::dsn::task::set_tls_dsn_context(n.second, nullptr, nullptr);

--- a/src/core/src/service_engine.h
+++ b/src/core/src/service_engine.h
@@ -95,8 +95,8 @@ public:
 
     task_engine* computation() const { return _computation; }
     const std::list<io_engine>& ios() const { return _ios; }
-    void get_runtime_info(const std::string& indent, const std::vector<std::string>& args, /*out*/ std::stringstream& ss);
-    void get_queue_info(/*out*/ std::stringstream& ss);
+    void get_runtime_info(const safe_string& indent, const safe_vector<safe_string>& args, /*out*/ safe_sstream& ss);
+    void get_queue_info(/*out*/ safe_sstream& ss);
 
     error_code start_io_engine_in_node_start_task(const io_engine& io);
 
@@ -116,7 +116,7 @@ public:
     void handle_l2_rpc_request(dsn_gpid gpid, bool is_write, dsn_message_t req);
     rpc_request_task* generate_l2_rpc_request_task(message_ex* req);
 
-    static dsn_error_t start_app(void* app_context, const std::string& args, dsn_app_start start, const std::string& app_name);
+    static dsn_error_t start_app(void* app_context, const safe_string& args, dsn_app_start start, const safe_string& app_name);
 
 private:
     dsn_app_info     _app_info;
@@ -150,8 +150,8 @@ public:
     env_provider* env() const { return _env; }
     logging_provider* logging() const { return _logging; }
     memory_provider* memory() const { return _memory; }
-    static std::string get_runtime_info(const std::vector<std::string>& args);
-    static std::string get_queue_info(const std::vector<std::string>& args);
+    static safe_string get_runtime_info(const safe_vector<safe_string>& args);
+    static safe_string get_queue_info(const safe_vector<safe_string>& args);
 
     void init_before_toollets(const service_spec& spec);
     void init_after_toollets();

--- a/src/core/src/task_engine.cpp
+++ b/src/core/src/task_engine.cpp
@@ -203,9 +203,10 @@ bool task_worker_pool::shared_same_worker_with_current_task(task* tsk) const
     }
 }
 
-void task_worker_pool::get_runtime_info(const std::string& indent, const std::vector<std::string>& args, /*out*/ std::stringstream& ss)
+void task_worker_pool::get_runtime_info(const safe_string& indent, 
+    const safe_vector<safe_string>& args, /*out*/ safe_sstream& ss)
 {
-    std::string indent2 = indent + "\t";
+    auto indent2 = indent + "\t";
     ss << indent << "contains " << _workers.size() << " threads with " << _queues.size() << " queues" << std::endl;
     
     for (auto& q : _queues)
@@ -224,7 +225,7 @@ void task_worker_pool::get_runtime_info(const std::string& indent, const std::ve
         }
     }
 }
-void task_worker_pool::get_queue_info(/*out*/ std::stringstream& ss)
+void task_worker_pool::get_queue_info(/*out*/ safe_sstream& ss)
 {
     ss << "[";
     bool first_flag = 0;
@@ -248,7 +249,7 @@ task_engine::task_engine(service_node* node)
     _node = node;
 }
 
-void task_engine::create(const std::list<dsn_threadpool_code_t>& pools)
+void task_engine::create(const safe_list<dsn_threadpool_code_t>& pools)
 {
     if (_is_running)
         return;
@@ -288,9 +289,10 @@ volatile int* task_engine::get_task_queue_virtual_length_ptr(
     return pl->queues()[idx]->get_virtual_length_ptr();
 }
 
-void task_engine::get_runtime_info(const std::string& indent, const std::vector<std::string>& args, /*out*/ std::stringstream& ss)
+void task_engine::get_runtime_info(const safe_string& indent, 
+    const safe_vector<safe_string>& args, /*out*/ safe_sstream& ss)
 {
-    std::string indent2 = indent + "\t";
+    auto indent2 = indent + "\t";
     for (auto& p : _pools)
     {
         if (p)
@@ -301,7 +303,7 @@ void task_engine::get_runtime_info(const std::string& indent, const std::vector<
     }
 }
 
-void task_engine::get_queue_info(/*out*/ std::stringstream& ss)
+void task_engine::get_queue_info(/*out*/ safe_sstream& ss)
 {
     bool first_flag = 0;
     for (auto& p : _pools)

--- a/src/core/src/task_engine.h
+++ b/src/core/src/task_engine.h
@@ -73,8 +73,8 @@ public:
     bool shared_same_worker_with_current_task(task* task) const;
     task_engine* engine() const { return _owner; }
     service_node* node() const { return _node; }
-    void get_runtime_info(const std::string& indent, const std::vector<std::string>& args, /*out*/ std::stringstream& ss);
-    void get_queue_info(/*out*/ std::stringstream& ss);
+    void get_runtime_info(const safe_string& indent, const safe_vector<safe_string>& args, /*out*/ safe_sstream& ss);
+    void get_queue_info(/*out*/ safe_sstream& ss);
     std::vector<task_queue*>& queues() { return _queues; }
     std::vector<task_worker*>& workers() { return _workers; }
     std::vector<admission_controller*>& controllers() { return _controllers; }
@@ -103,7 +103,7 @@ public:
     //
     // service management routines
     //
-    void create(const std::list<dsn_threadpool_code_t>& pools);
+    void create(const safe_list<dsn_threadpool_code_t>& pools);
     void start();
 
     //
@@ -120,8 +120,8 @@ public:
         );
 
     service_node* node() const { return _node; }
-    void get_runtime_info(const std::string& indent, const std::vector<std::string>& args, /*out*/ std::stringstream& ss);
-    void get_queue_info(/*out*/ std::stringstream& ss);
+    void get_runtime_info(const safe_string& indent, const safe_vector<safe_string>& args, /*out*/ safe_sstream& ss);
+    void get_queue_info(/*out*/ safe_sstream& ss);
 private:
     std::vector<task_worker_pool*> _pools;
     volatile bool                  _is_running;

--- a/src/core/src/task_engine.test.cpp
+++ b/src/core/src/task_engine.test.cpp
@@ -88,8 +88,8 @@ TEST(core, task_engine)
     ASSERT_NE(nullptr, engine);
 
     ASSERT_TRUE(engine->is_started());
-    std::vector<std::string> args;
-    std::stringstream oss;
+    safe_vector<safe_string> args;
+    safe_sstream oss;
     engine->get_runtime_info("  ", args, oss);
     printf("%s\n", oss.str().c_str());
 

--- a/src/core/src/task_spec.cpp
+++ b/src/core/src/task_spec.cpp
@@ -180,7 +180,9 @@ bool task_spec::init()
             "invalid length of rpc_request_delays_milliseconds, must be of length 6");
         if (spec->rpc_request_delays_milliseconds.size() > 0)
         {
-            spec->rpc_request_delayer.initialize(spec->rpc_request_delays_milliseconds);
+            std::vector<int> mss{ spec->rpc_request_delays_milliseconds.begin(),
+                spec->rpc_request_delays_milliseconds.end() };
+            spec->rpc_request_delayer.initialize(mss);
         }
 
         if (spec->rpc_request_throttling_mode != TM_NONE)
@@ -198,9 +200,9 @@ bool task_spec::init()
     ::dsn::register_command("task-code", 
         "task-code - query task code containing any given keywords",        
         "task-code keyword1 keyword2 ...",
-        [](const std::vector<std::string>& args)
+        [](const safe_vector<safe_string>& args)
         {
-            std::stringstream ss;
+            safe_sstream ss;
 
             for (int code = 0; code <= dsn_task_code_max(); code++)
             {
@@ -232,7 +234,7 @@ bool task_spec::init()
 }
 
 
-bool threadpool_spec::init(/*out*/ std::vector<threadpool_spec>& specs)
+bool threadpool_spec::init(/*out*/ safe_vector<threadpool_spec>& specs)
 {
     /*
     [threadpool..default]
@@ -272,7 +274,7 @@ bool threadpool_spec::init(/*out*/ std::vector<threadpool_spec>& specs)
         spec.pool_code = code;
 
         if ("" == spec.name) 
-            spec.name = std::string(dsn_threadpool_code_to_string(code));
+            spec.name = dsn_threadpool_code_to_string(code);
 
         if (false == spec.worker_share_core && 0 == spec.worker_affinity_mask)
         {

--- a/src/core/src/task_worker.cpp
+++ b/src/core/src/task_worker.cpp
@@ -73,7 +73,7 @@ task_worker::task_worker(task_worker_pool* pool, task_queue* q, int index, task_
 
     char name[256];
     sprintf(name, "%5s.%s.%u", pool->node()->name(), pool->spec().name.c_str(), index);
-    _name = std::string(name);
+    _name = name;
     _is_running = false;
 
     _thread = nullptr;

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -134,6 +134,41 @@ namespace dsn {
                 }
             }
         }
+
+        void split_args(const char* args, /*out*/ safe_vector<safe_string>& sargs, char splitter)
+        {
+            sargs.clear();
+
+            safe_string v(args);
+
+            int lastPos = 0;
+            while (true)
+            {
+                auto pos = v.find(splitter, lastPos);
+                if (pos != safe_string::npos)
+                {
+                    safe_string s = v.substr(lastPos, pos - lastPos);
+                    if (s.length() > 0)
+                    {
+                        safe_string s2 = trim_string((char*)s.c_str());
+                        if (s2.length() > 0)
+                            sargs.push_back(s2);
+                    }
+                    lastPos = static_cast<int>(pos + 1);
+                }
+                else
+                {
+                    safe_string s = v.substr(lastPos);
+                    if (s.length() > 0)
+                    {
+                        safe_string s2 = trim_string((char*)s.c_str());
+                        if (s2.length() > 0)
+                            sargs.push_back(s2);
+                    }
+                    break;
+                }
+            }
+        }
         
         void split_args(const char* args, /*out*/ std::list<std::string>& sargs, char splitter)
         {
@@ -170,6 +205,41 @@ namespace dsn {
             }
         }
 
+        void split_args(const char* args, /*out*/ safe_list<safe_string>& sargs, char splitter)
+        {
+            sargs.clear();
+
+            safe_string v(args);
+
+            int lastPos = 0;
+            while (true)
+            {
+                auto pos = v.find(splitter, lastPos);
+                if (pos != safe_string::npos)
+                {
+                    safe_string s = v.substr(lastPos, pos - lastPos);
+                    if (s.length() > 0)
+                    {
+                        safe_string s2 = trim_string((char*)s.c_str());
+                        if (s2.length() > 0)
+                            sargs.push_back(s2);
+                    }
+                    lastPos = static_cast<int>(pos + 1);
+                }
+                else
+                {
+                    safe_string s = v.substr(lastPos);
+                    if (s.length() > 0)
+                    {
+                        safe_string s2 = trim_string((char*)s.c_str());
+                        if (s2.length() > 0)
+                            sargs.push_back(s2);
+                    }
+                    break;
+                }
+            }
+        }
+        
         std::string replace_string(std::string subject, const std::string& search, const std::string& replace) 
         {
             size_t pos = 0;

--- a/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
+++ b/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
@@ -271,7 +271,7 @@ namespace dsn
             auto msg = dsn_msg_create_request(RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX);
 
             configuration_query_by_index_request req;
-            req.app_name = _app_path;
+            req.app_name = _app_path.c_str();
             if (partition_index != -1)
             {
                 req.partition_indices.push_back(partition_index);

--- a/src/plugins/tools.common/fault_injector.cpp
+++ b/src/plugins/tools.common/fault_injector.cpp
@@ -185,7 +185,7 @@ namespace dsn {
         }
 
         
-        static void replace_value(std::vector<blob>& buffer_list, unsigned int offset)
+        static void replace_value(safe_vector<blob>& buffer_list, unsigned int offset)
         {
             for (blob& bb: buffer_list)
             {

--- a/src/plugins/tools.common/profiler_command.cpp
+++ b/src/plugins/tools.common/profiler_command.cpp
@@ -86,14 +86,14 @@ namespace dsn {
             return it->second;
         }
 
-        std::string profiler_output_handler(const std::vector<std::string>& args)
+        safe_string profiler_output_handler(const safe_vector<safe_string>& args)
         {
-            std::stringstream ss;
+            ::std::stringstream ss;
 
             if (args.size() < 1)
             {
                 ss << "unenough arguments" << std::endl;
-                return ss.str();
+                return ss.str().c_str();
             }
 
             if ((args[0] == "dependency") || (args[0] == "dep"))
@@ -101,38 +101,38 @@ namespace dsn {
                 if (args.size() < 2)
                 {
                     ss << "unenough arguments" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 if (args[1] == "matrix")
                 {
                     profiler_output_dependency_matrix(ss);
-                    return ss.str();
+                    return ss.str().c_str();
                 }
                 if (args[1] == "list")
                 {
                     if (args.size() < 3)
                     {
                         profiler_output_dependency_list_caller(ss, -1);
-                        return ss.str();
+                        return ss.str().c_str();
                     }
 
                     if (args[2] == "caller")
                     {
                         profiler_output_dependency_list_caller(ss, -1);
-                        return ss.str();
+                        return ss.str().c_str();
                     }
                     if (args[2] == "callee")
                     {
                         profiler_output_dependency_list_callee(ss, -1);
-                        return ss.str();
+                        return ss.str().c_str();
                     }
 
-                    int task_id = find_task_id(args[2]);
+                    int task_id = find_task_id(args[2].c_str());
                     if (task_id == TASK_CODE_INVALID)
                     {
                         ss << "no such task" << std::endl;
-                        return ss.str();
+                        return ss.str().c_str();
                     }
 
                     if ((args.size() > 3) && (args[3] == "callee"))
@@ -144,22 +144,22 @@ namespace dsn {
                         profiler_output_dependency_list_caller(ss, task_id);
                     }
 
-                    return ss.str();
+                    return ss.str().c_str();
                 }
                 ss << "wrong arguments" << std::endl;
-                return ss.str();
+                return ss.str().c_str();
             }
             else if (args[0] == "info")
             {
                 int task_id = -1;
                 if ((args.size() > 1) && (args[1] != "all"))
                 {
-                    task_id = find_task_id(args[1]);
+                    task_id = find_task_id(args[1].c_str());
                 }
                 if (task_id == TASK_CODE_INVALID)
                 {
                     ss << "no such task" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 profiler_output_information_table(ss, task_id);
@@ -169,68 +169,69 @@ namespace dsn {
                 if (args.size() < 3)
                 {
                     ss << "unenough arguments" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 int num = atoi(args[1].c_str());
                 if (num == 0)
                 {
                     ss << "not a legal value" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
-                perf_counter_ptr_type counter_type = find_counter_type(args[2]);
+                perf_counter_ptr_type counter_type = find_counter_type(args[2].c_str());
                 if (counter_type == PREF_COUNTER_INVALID)
                 {
                     ss << "no such counter type" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 dsn_perf_counter_percentile_type_t percentile_type = COUNTER_PERCENTILE_50;
-                if ((args.size() > 3) && (find_percentail_type(args[3]) != COUNTER_PERCENTILE_INVALID))
+                if ((args.size() > 3) && (find_percentail_type(args[3].c_str()) != COUNTER_PERCENTILE_INVALID))
                 {
-                    percentile_type = find_percentail_type(args[3]);
+                    percentile_type = find_percentail_type(args[3].c_str());
                 }
 
                 profiler_output_top(ss, counter_type, percentile_type, num);
             }
             else
                 ss << "wrong arguments" << std::endl;
-            return ss.str();
+            return ss.str().c_str();
         }
-        std::string profiler_data_handler(const std::vector<std::string>& args)
+
+        safe_string profiler_data_handler(const safe_vector<safe_string>& args)
         {
             int k = static_cast<int>(args.size());
             int task_id;
             perf_counter_ptr_type counter_type;
             dsn_perf_counter_percentile_type_t percentile_type;
-            std::stringstream ss;
-            std::vector<std::string> val;
+            ::std::stringstream ss;
+            safe_vector<safe_string> val;
 
             if ((args.size() > 0) && (args[0] == "top"))
             {
                 if (k < 4)
                 {
-                    return ss.str();
+                    return ss.str().c_str();
                 }
                 int num = atoi(args[1].c_str());
-                counter_type = find_counter_type(args[2]);
-                percentile_type = find_percentail_type(args[3]);
+                counter_type = find_counter_type(args[2].c_str());
+                percentile_type = find_percentail_type(args[3].c_str());
 
                 if ((num == 0) || (counter_type == PREF_COUNTER_INVALID) || (percentile_type == COUNTER_PERCENTILE_INVALID))
                 {
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 profiler_data_top(ss, counter_type, percentile_type, num);
-                return ss.str();
+                return ss.str().c_str();
             }
 
             for (int i = 0; i < k; i++)
             {
                 utils::split_args(args[i].c_str(), val, ':');
-                task_id = find_task_id(val[0]);
-                counter_type = find_counter_type(val[1]);
-                percentile_type = find_percentail_type(val[2]);
+                task_id = find_task_id(val[0].c_str());
+                counter_type = find_counter_type(val[1].c_str());
+                percentile_type = find_percentail_type(val[2].c_str());
 
                 if ((task_id != TASK_CODE_INVALID) && (counter_type != PREF_COUNTER_INVALID) && (s_spec_profilers[task_id].ptr[counter_type] != NULL) && (s_spec_profilers[task_id].is_profile != false))
                 {
@@ -255,7 +256,7 @@ namespace dsn {
                     }
                 }
             }
-            return ss.str();
+            return ss.str().c_str();
         }
 
         struct call_link {
@@ -287,14 +288,15 @@ namespace dsn {
             std::vector<nv_pair> data;
             DEFINE_JSON_SERIALIZATION(time, data)
         };
-        std::string query_data_handler(const std::vector<std::string>& args)
+
+        safe_string query_data_handler(const safe_vector<safe_string>& args)
         {
-            std::stringstream ss;
+            ::std::stringstream ss;
 
             if (args.size() < 1)
             {
                 ss << "incorrect arguments" << std::endl;
-                return ss.str();
+                return ss.str().c_str();
             }
 
             //return a matrix for all task codes contained with perf_counter percentile value
@@ -361,7 +363,7 @@ namespace dsn {
                     }
                 }
                 ss << "]";
-                return ss.str();
+                return ss.str().c_str();
             }
             //return a list of names of all task codes
             else if (args[0] == "task_list")
@@ -379,7 +381,7 @@ namespace dsn {
 
                 }
                 dsn::json::json_encode(ss,task_list);
-                return ss.str();
+                return ss.str().c_str();
             }
             //return a list of 2 elements for a specific task:
             //1. a list of all perf_counters
@@ -389,15 +391,15 @@ namespace dsn {
                 if (args.size() < 2)
                 {
                     ss << "unenough arguments" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
-                int task_id = find_task_id(args[1]);
+                int task_id = find_task_id(args[1].c_str());
 
                 if ((task_id == TASK_CODE_INVALID) || (s_spec_profilers[task_id].is_profile == false))
                 {
                     ss << "no such task code or target task is not profiled" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 if (task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE)
@@ -472,7 +474,7 @@ namespace dsn {
                 } while (task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE);
 
                 dsn::json::json_encode(ss, total_resp);
-                return ss.str();
+                return ss.str().c_str();
             }
             //return 6 types of latency times for a specific task
             else if (args[0] == "counter_breakdown")
@@ -480,16 +482,16 @@ namespace dsn {
                 if (args.size() < 2)
                 {
                     ss << "unenough arguments" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
-                int task_id = find_task_id(args[1]);
+                int task_id = find_task_id(args[1].c_str());
                 int query_percentile = (args.size() == 2) ? 50 : atoi(args[2].c_str());
                 
 
                 if ((task_id == TASK_CODE_INVALID) || (s_spec_profilers[task_id].is_profile == false))
                 {
                     ss << "no such task code or target task is not profiled" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 if (task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE)
@@ -552,7 +554,7 @@ namespace dsn {
                 //timeList[3] = timeList[0];
 
                 dsn::json::json_encode(ss, timeList);
-                return ss.str();
+                return ss.str().c_str();
             }
             //return a list of current counter value for a specific task
             else if (args[0] == "counter_realtime")
@@ -560,15 +562,15 @@ namespace dsn {
                 if (args.size() < 2)
                 {
                     ss << "unenough arguments" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
-                int task_id = find_task_id(args[1]);
+                int task_id = find_task_id(args[1].c_str());
 
                 if ((task_id == TASK_CODE_INVALID) || (s_spec_profilers[task_id].is_profile == false))
                 {
                     ss << "no such task code or target task is not profiled" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 char str[24];
@@ -616,7 +618,7 @@ namespace dsn {
                 } while (task_spec::get(task_id)->type == TASK_TYPE_RPC_RESPONSE);
 
                 counter_realtime_resp{ std::string(str), data }.encode_json_state(ss);
-                return ss.str();
+                return ss.str().c_str();
             }
             //return a list of 2 elements for a specific task
             //1. a list of caller names and call times 
@@ -626,7 +628,7 @@ namespace dsn {
                 if (args.size() < 1)
                 {
                     ss << "unenough arguments" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
                 else if (args.size() == 1)
                 {
@@ -637,7 +639,7 @@ namespace dsn {
                     {
                         if ((j != TASK_CODE_INVALID) && (s_spec_profilers[j].is_profile))
                         {
-                            task_list.push_back(std::string(dsn_task_code_to_string(j)));
+                            task_list.push_back(dsn_task_code_to_string(j));
                         
                             std::vector<uint64_t> call_vector;
                             for (int k = 0; k <= dsn_task_code_max(); k++)
@@ -652,15 +654,15 @@ namespace dsn {
                     }
 
                     call_resp{ task_list, call_matrix }.encode_json_state(ss);
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
-                int task_id = find_task_id(args[1]);
+                int task_id = find_task_id(args[1].c_str());
 
                 if ((task_id == TASK_CODE_INVALID) || (s_spec_profilers[task_id].is_profile == false))
                 {
                     ss << "no such task code or target task is not profiled" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
                 std::vector<std::vector<call_link>> call_list;
                 std::vector<call_link> caller_list;
@@ -693,7 +695,7 @@ namespace dsn {
                 call_list.push_back(caller_list);
                 call_list.push_back(callee_list);
                 dsn::json::json_encode(ss, call_list);
-                return ss.str();
+                return ss.str().c_str();
             }
             //return a list of all sharer using the same pool with a specific task
             else if (args[0] == "pool_sharer")
@@ -701,15 +703,15 @@ namespace dsn {
                 if (args.size() < 2)
                 {
                     ss << "unenough arguments" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
-                int task_id = find_task_id(args[1]);
+                int task_id = find_task_id(args[1].c_str());
 
                 if ((task_id == TASK_CODE_INVALID) || (s_spec_profilers[task_id].is_profile == false))
                 {
                     ss << "no such task code or target task is not profiled" << std::endl;
-                    return ss.str();
+                    return ss.str().c_str();
                 }
 
                 auto pool = task_spec::get(task_id)->pool_code;
@@ -717,9 +719,9 @@ namespace dsn {
                 std::vector<std::string> sharer_list;
                 for (int j = 0; j <= dsn_task_code_max(); j++)
                 if (j != TASK_CODE_INVALID && j != task_id && task_spec::get(j)->pool_code == pool && task_spec::get(j)->type == TASK_TYPE_RPC_RESPONSE)
-                    sharer_list.push_back(std::string(dsn_task_code_to_string(j)));
+                    sharer_list.push_back(dsn_task_code_to_string(j));
                 dsn::json::json_encode(ss, sharer_list);
-                return ss.str();
+                return ss.str().c_str();
             }
             //query time
             else if (args[0] == "time")
@@ -727,12 +729,12 @@ namespace dsn {
                 char str[24];
                 ::dsn::utils::time_ms_to_string(dsn_now_ns() / 1000000, str);
                 ss << str;
-                return ss.str();
+                return ss.str().c_str();
             }
             else
             {
                 ss << "wrong parameter";
-                return ss.str();
+                return ss.str().c_str();
             }
         }
     }

--- a/src/plugins/tools.common/profiler_header.h
+++ b/src/plugins/tools.common/profiler_header.h
@@ -96,7 +96,7 @@ namespace dsn {
         public:
             profiler_output_data_type(int name_width, int data_width, int call_width)
             {
-                std::stringstream namess, datass, tmpss;
+                ::std::stringstream namess, datass, tmpss;
                 int tmp;
 
                 for (int i = 0; i < name_width; i++)
@@ -226,17 +226,17 @@ namespace dsn {
             }
         };
 
-        std::string profiler_output_handler(const std::vector<std::string>& args);
-        std::string profiler_js_handler(const std::vector<std::string>& args);
-        std::string profiler_data_handler(const std::vector<std::string>& args);
-        std::string query_data_handler(const std::vector<std::string>& args);
+        safe_string profiler_output_handler(const safe_vector<safe_string>& args);
+        safe_string profiler_js_handler(const safe_vector<safe_string>& args);
+        safe_string profiler_data_handler(const safe_vector<safe_string>& args);
+        safe_string query_data_handler(const safe_vector<safe_string>& args);
 
-        void profiler_output_dependency_list_callee(std::stringstream &ss, const int task_id);
-        void profiler_output_dependency_list_caller(std::stringstream &ss, const int task_id);
-        void profiler_output_dependency_matrix(std::stringstream &ss);
-        void profiler_output_information_table(std::stringstream &ss, const int task_id);
-        void profiler_output_infomation_line(std::stringstream &ss, const int task_id, dsn_perf_counter_percentile_type_t percentile_type, const bool full_data);
-        void profiler_output_top(std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num);
-        void profiler_data_top(std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num);
+        void profiler_output_dependency_list_callee(::std::stringstream &ss, const int task_id);
+        void profiler_output_dependency_list_caller(::std::stringstream &ss, const int task_id);
+        void profiler_output_dependency_matrix(::std::stringstream &ss);
+        void profiler_output_information_table(::std::stringstream &ss, const int task_id);
+        void profiler_output_infomation_line(::std::stringstream &ss, const int task_id, dsn_perf_counter_percentile_type_t percentile_type, const bool full_data);
+        void profiler_output_top(::std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num);
+        void profiler_data_top(::std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num);
     }
 }

--- a/src/plugins/tools.common/profiler_output.cpp
+++ b/src/plugins/tools.common/profiler_output.cpp
@@ -68,7 +68,7 @@ namespace dsn {
             return x.val > y.val;
         }
 
-        void profiler_output_top(std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num)
+        void profiler_output_top(::std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num)
         {
             sort_node *_tmp = new sort_node[dsn_task_code_max() + 3];
             int tmp_num = (num >= dsn_task_code_max() + 1) ? dsn_task_code_max() + 1 : num;
@@ -118,7 +118,7 @@ namespace dsn {
             delete[] _tmp;
         }
 
-        void profiler_output_infomation_line(std::stringstream &ss, const int task_id, dsn_perf_counter_percentile_type_t percentile_type, const bool full_data)
+        void profiler_output_infomation_line(::std::stringstream &ss, const int task_id, dsn_perf_counter_percentile_type_t percentile_type, const bool full_data)
         {
             //Print the table infrom
             if (full_data == true)
@@ -171,7 +171,7 @@ namespace dsn {
             ss << std::endl;
         }
 
-        void profiler_output_information_table(std::stringstream &ss, const int task_id)
+        void profiler_output_information_table(::std::stringstream &ss, const int task_id)
         {
             ss << profiler_output_data->separate_line_info << std::endl;
             ss << "|PROFILE|" << profiler_output_data->view_task_type << "PERCENT|";
@@ -212,7 +212,7 @@ namespace dsn {
             }
         }
 
-        void profiler_output_dependency_matrix(std::stringstream &ss)
+        void profiler_output_dependency_matrix(::std::stringstream &ss)
         {
             //Print the separate line
             ss << profiler_output_data->separate_line_depmatrix;
@@ -276,7 +276,7 @@ namespace dsn {
             }
         }
 
-        void profiler_output_dependency_list_caller(std::stringstream &ss, const int task_id)
+        void profiler_output_dependency_list_caller(::std::stringstream &ss, const int task_id)
         {
             //Print the title of table
             ss << profiler_output_data->separate_line_deplist << std::endl;
@@ -320,7 +320,7 @@ namespace dsn {
             }
         }
 
-        void profiler_output_dependency_list_callee(std::stringstream &ss, const int task_id)
+        void profiler_output_dependency_list_callee(::std::stringstream &ss, const int task_id)
         {
             //Print the title of table
             ss << profiler_output_data->separate_line_deplist << std::endl;
@@ -364,7 +364,7 @@ namespace dsn {
             }
         }
 
-        void profiler_data_top(std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num)
+        void profiler_data_top(::std::stringstream &ss, const perf_counter_ptr_type counter_type, const dsn_perf_counter_percentile_type_t percentile_type, const int num)
         {
             sort_node *_tmp = new sort_node[dsn_task_code_max() + 3];
             int tmp_num = num >= dsn_task_code_max() + 1 ? dsn_task_code_max() + 1 : num;

--- a/src/plugins/tools.common/simulator.cpp
+++ b/src/plugins/tools.common/simulator.cpp
@@ -133,7 +133,7 @@ void simulator::install(service_spec& spec)
 
 void simulator::on_system_init_for_add_global_checker()
 {
-    std::list<global_checker> checkers;
+    safe_vector<global_checker> checkers;
     ::dsn::get_registered_checkers(checkers);
 
     auto t = dynamic_cast<dsn::tools::simulator*>(::dsn::tools::get_current_tool());

--- a/src/plugins/tools.common/tracer.cpp
+++ b/src/plugins/tools.common/tracer.cpp
@@ -240,12 +240,12 @@ namespace dsn {
         };
 
 
-        static std::string tracer_log_flow_error(const char* msg)
+        static safe_string tracer_log_flow_error(const char* msg)
         {
-            return std::string("invalid arguments for tracer.find: ") + msg;
+            return safe_string("invalid arguments for tracer.find: ") + msg;
         }
 
-        static std::string tracer_log_flow(const std::vector<std::string>& args)
+        static safe_string tracer_log_flow(const safe_vector<safe_string>& args)
         {
             // forward|f|backward|b rpc|r|task|t trace_id|task_id(e.g., 002a003920302390) log_file_name(log.xx.txt)
             if (args.size() < 4)
@@ -285,13 +285,13 @@ namespace dsn {
             }
 
             std::string log_dir = utils::filesystem::path_combine(
-                tools::spec().data_dir,
+                tools::spec().data_dir.c_str(),
                 "logs"
                 );
 
             std::string fpath = utils::filesystem::path_combine(
                 log_dir,
-                args[3]
+                args[3].c_str()
                 );
 
             if (!utils::filesystem::file_exists(fpath))

--- a/src/plugins/tools.nfs/nfs_client_impl.cpp
+++ b/src/plugins/tools.nfs/nfs_client_impl.cpp
@@ -44,9 +44,12 @@ namespace dsn {
         {
             user_request* req = new user_request();
             req->file_size_req.source = rci->source;
-            req->file_size_req.dst_dir = rci->dest_dir;
-            req->file_size_req.file_list = rci->files;
-            req->file_size_req.source_dir = rci->source_dir;
+            req->file_size_req.dst_dir = rci->dest_dir.c_str();
+            for (auto& f : rci->files)
+            {
+                req->file_size_req.file_list.emplace_back(f.c_str());
+            }
+            req->file_size_req.source_dir = rci->source_dir.c_str();
             req->file_size_req.overwrite = rci->overwrite;
             req->nfs_task = nfs_task;
             req->is_finished = false;


### PR DESCRIPTION
…be allocated in one dll while released in another, which causes crashes when the memory allocator and deallocator are not consistent. We therefore introduce safe_xxx to enforce the same memory allocator for those containers defined in different dlls.
